### PR TITLE
Enable RLS on public data tables with read-only policies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ Migrations must be run in this order:
 3. `migrations/003_create_profiles_table.sql` - Creates user profiles table with RLS policies (requires Supabase Auth)
 4. `migrations/004_create_location_submissions.sql` - Creates location_submissions table for user submissions with RLS policies
 5. `migrations/005_create_favorites_table.sql` - Creates user_favorites table with RLS policies
+6. `migrations/006_enable_rls_public_tables.sql` - Enables RLS on public data tables (sites, descriptions, menu, hours, salsa, protein, summaries, specs) with read-only access policies
 
 ## State Management Architecture
 

--- a/migrations/006_enable_rls_public_tables.sql
+++ b/migrations/006_enable_rls_public_tables.sql
@@ -1,0 +1,107 @@
+-- Migration 006: Enable RLS on public data tables with read-only access policies
+-- Supabase flags all tables without RLS enabled as a security concern.
+-- These tables contain public, read-only data (taco establishment info).
+-- Enabling RLS with SELECT-only policies ensures:
+--   1. Data remains publicly readable by anon and authenticated users
+--   2. INSERT/UPDATE/DELETE are blocked at the RLS level (only service role can write)
+--   3. Supabase security advisor warnings are resolved
+
+-- ============================================================
+-- sites table
+-- ============================================================
+ALTER TABLE public.sites ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow public read access"
+  ON public.sites
+  FOR SELECT
+  USING (true);
+
+-- ============================================================
+-- descriptions table
+-- ============================================================
+ALTER TABLE public.descriptions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow public read access"
+  ON public.descriptions
+  FOR SELECT
+  USING (true);
+
+-- ============================================================
+-- menu table
+-- ============================================================
+ALTER TABLE public.menu ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow public read access"
+  ON public.menu
+  FOR SELECT
+  USING (true);
+
+-- ============================================================
+-- hours table
+-- ============================================================
+ALTER TABLE public.hours ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow public read access"
+  ON public.hours
+  FOR SELECT
+  USING (true);
+
+-- ============================================================
+-- salsa table
+-- ============================================================
+ALTER TABLE public.salsa ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow public read access"
+  ON public.salsa
+  FOR SELECT
+  USING (true);
+
+-- ============================================================
+-- protein table
+-- ============================================================
+ALTER TABLE public.protein ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow public read access"
+  ON public.protein
+  FOR SELECT
+  USING (true);
+
+-- ============================================================
+-- summaries table
+-- ============================================================
+ALTER TABLE public.summaries ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow public read access"
+  ON public.summaries
+  FOR SELECT
+  USING (true);
+
+-- ============================================================
+-- item_spec table
+-- ============================================================
+ALTER TABLE public.item_spec ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow public read access"
+  ON public.item_spec
+  FOR SELECT
+  USING (true);
+
+-- ============================================================
+-- protein_spec table
+-- ============================================================
+ALTER TABLE public.protein_spec ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow public read access"
+  ON public.protein_spec
+  FOR SELECT
+  USING (true);
+
+-- ============================================================
+-- salsa_spec table
+-- ============================================================
+ALTER TABLE public.salsa_spec ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow public read access"
+  ON public.salsa_spec
+  FOR SELECT
+  USING (true);


### PR DESCRIPTION
## Summary
This PR enables Row Level Security (RLS) on all public data tables and implements read-only access policies to resolve Supabase security advisor warnings while maintaining public data accessibility.

## Changes
- **New migration**: `migrations/006_enable_rls_public_tables.sql`
  - Enables RLS on 10 public tables: `sites`, `descriptions`, `menu`, `hours`, `salsa`, `protein`, `summaries`, `item_spec`, `protein_spec`, and `salsa_spec`
  - Creates "Allow public read access" SELECT-only policies for each table
  - Allows anonymous and authenticated users to read data while blocking INSERT/UPDATE/DELETE at the RLS level

- **Documentation**: Updated `CLAUDE.md` to include the new migration in the ordered migration sequence

## Implementation Details
- All policies use `USING (true)` to permit unrestricted SELECT access for public, read-only data
- Write operations remain restricted to the service role, enforced at the RLS level rather than application logic
- Consistent policy naming and structure across all tables for maintainability
- Comprehensive inline comments explaining the security rationale and benefits

https://claude.ai/code/session_01FGDHkt85yUmnNE21gWRdVr