### PR TITLE
Housekeeping, dark mode polish, Taco Trail Builder, and radar chart fix

### DIFF
--- a/src/lib/dataWrangling.js
+++ b/src/lib/dataWrangling.js
@@ -22,20 +22,21 @@ export function filterObjectByKeySubstring(obj, substring) {
 }
 
 /**
- * Function to get the top five items based on the second item of the subarray
+ * Function to get the top N items based on the second item of the subarray
  * and strip the '_perc' suffix from the keys
  * @param {Array} arr - The array of arrays to process
- * @return {Array} - An array with the top five items
+ * @param {number} n - Number of top items to return (default 5)
+ * @return {Array} - An array with the top N items
  */
-export function getTopFive(arr) {
+export function getTopFive(arr, n = 5) {
     // Sort the array based on the second item of the subarrays in descending order
     arr.sort((a, b) => b[1] - a[1]);
 
-    // Get the top five items
-    const topFive = arr.slice(0, 5);
+    // Get the top N items
+    const topN = arr.slice(0, n);
 
     // Strip the '_perc' suffix from the keys
-    return topFive.map(([key, value]) => [key.replace('_perc', ''), value]);
+    return topN.map(([key, value]) => [key.replace('_perc', ''), value]);
 }
 
 export function percentageOfMaxArray(arr) {

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -66,8 +66,16 @@ export const processedTacoData = derived(
         const startHours = filterObjectByKeySubstring(site.hours, "start");
         const endHours = filterObjectByKeySubstring(site.hours, "end");
 
+        // Filter to items the establishment actually serves (_yes = true) before ranking,
+        // so the radar only shows offered items rather than cutting off real ones
+        // due to global top-5 competition with the full 16-item pool.
+        const activeMenuPercs = menuPercs.filter(([key]) => {
+          const yesKey = key.replace('_perc', '_yes');
+          return site.menu[yesKey] === true;
+        });
+
         // Pre-compute top five menu items and proteins
-        const menuArray = getTopFive(menuPercs);
+        const menuArray = getTopFive(activeMenuPercs, 7);
         const topFiveMenuItems = menuArray.map(subArray => subArray[0]);
         // Convert to numbers and multiply by 100 to get percentages
         const topFiveMenuValues = menuArray.map(subArray => {


### PR DESCRIPTION
## Summary

- **Dark mode polish** — dark icon variants for all establishment/protein/specialty icons, logo glow treatment, fixed navbar and map controls in dark theme, hover tooltips on icon highlights
- **Search improvement** — generalized search now matches across name, menu items, type, descriptions, and specialties (not just name)
- **Icon swap** — specialty item cards use a dedicated `specialty_menu` icon instead of the generic corn icon
- **Taco Trail Builder** — new interactive route-building feature (see below)
- **Radar chart fix** — menu chart now correctly shows all items an establishment serves

## Taco Trail Builder

Users can select multiple taco spots, see a visual route on the map, and open the full trip in Google Maps for navigation.

1. Click the route icon in the filter bar to enter trail mode
2. Tap any map marker to add it as a stop — numbered orange circles appear on the map
3. Use **📍 Start Here / End Here** to add current GPS location as a waypoint
4. Toggle **Walk / Drive** to switch routing profile — route redraws automatically
5. Reorder or remove stops in the bottom tray
6. **Get Directions** opens a multi-stop Google Maps route in a new tab
7. **Share Trail** encodes stops as `?trail=1,3,7&mode=walk` URL params and copies to clipboard — pasting the link reconstructs the full trail
8. Exiting trail mode clears all markers and the route line from the map

**Files added:** `src/lib/trailStore.js`, `src/components/TrailTray.svelte`
**Files modified:** `src/lib/mapping.js`, `src/routes/Map.svelte`, `src/components/FilterBar.svelte`

## Radar chart fix

The menu radar was sorting all 16 `_perc` columns globally and taking the top 5, which meant items with `_yes=true` (e.g. gordita, huarache) could be dropped if 5 other items happened to rank higher across the full pool. The fix:

- Pre-filters to only items where `_yes=true` before ranking, so the chart competes within what the establishment actually serves
- Increased cutoff from top 5 → top 7 to surface more of the menu
- `getTopFive` now accepts an optional `n` parameter (default 5) for future flexibility

## Test plan

- [ ] Dark mode: toggle theme, verify all icons/navbar/map controls render correctly
- [ ] Search: confirm matches on menu items, type, and descriptions — not just name
- [ ] Radar chart: open a spot with many menu items and confirm gordita/huarache (if served) appear
- [ ] Radar chart: confirm items with `_yes=false` do not appear even if they have a non-zero `_perc`
- [ ] Trail — enter trail mode via filter bar button (turns orange)
- [ ] Trail — click 3 markers, verify numbered orange circles and dashed route line appear
- [ ] Trail — toggle Walk/Drive and verify route redraws
- [ ] Trail — reorder and remove stops; markers and route update
- [ ] Trail — "📍 Start/End Here" adds current GPS location as a stop
- [ ] Trail — "Get Directions" opens correct Google Maps multi-stop URL
- [ ] Trail — "Share Trail" updates URL + copies; paste in new tab reconstructs trail
- [ ] Trail — exit trail mode; tray closes, route line and numbered markers fully removed
- [ ] Trail — switch dark/light theme while trail is active; layers persist after style reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)