### PR TITLE
Add Taco Summit: ranked-choice group voting feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-CartoTaco is an interactive map-based application for exploring taco establishments in Tucson, AZ. Built with SvelteKit, it features an optimized architecture that fetches all site data in a single database query using a Supabase view. The app supports user authentication, favorites, trail building (multi-stop route planning), location submissions, and theme switching.
+CartoTaco is an interactive map-based application for exploring taco establishments in Tucson, AZ. Built with SvelteKit, it features an optimized architecture that fetches all site data in a single database query using a Supabase view. The app supports user authentication, favorites, trail building (multi-stop route planning), location submissions, theme switching, and group decision voting (Taco Summit).
 
 ## Development Commands
 
@@ -60,6 +60,9 @@ Migrations must be run in this order:
 18. `migrations/018_rename_spec_fk_columns.sql` - Renames spec FK columns to consistent spec_id_N pattern, rebuilds view
 19. `migrations/019_drop_summaries_table.sql` - Drops the unused summaries table (stats now computed client-side)
 20. `migrations/020_drop_unused_sites_columns.sql` - Drops unused columns from sites table (contact, lat_2, lon_2, days_loc_2)
+21. `migrations/021_create_group_sessions.sql` - Creates `group_sessions` table for Taco Summit feature (id, creator_token, site_ids, title, closed_at) with open RLS policies
+22. `migrations/022_create_group_votes.sql` - Creates `group_votes` table for ranked-choice ballots (session_id, voter_token, est_id, rank) with unique constraint and index
+23. `migrations/023_add_snacks_menu_type.sql` - Adds snacks as a menu type
 
 ### Schema Management
 - **`schema/sites_complete_view.sql`** is the single source of truth for the `sites_complete` view definition
@@ -135,7 +138,7 @@ The app uses Svelte stores (src/lib/stores.js) for centralized state:
 - `tourActive` - Whether the tour overlay is showing
 - `tourStep` - Current step index (0-based)
 - `tourExpandFilters` - Whether to expand filters during the filters tour step
-- `TOUR_STEPS` - Array of 7 step definitions: `welcome`, `search`, `filters`, `trail`, `map`, `theme`, `done`
+- `TOUR_STEPS` - Array of 10 step definitions: `welcome`, `search`, `surprise`, `filters`, `trail`, `summit`, `map`, `theme`, `signup`, `done`
   - Each step has `id`, `target` (CSS selector or null for centered modal), `title`, `description`, optional `onEnter` action
 - Functions: `startTour()`, `endTour()`, `nextStep()`, `prevStep()`, `shouldAutoStart()`
 - Persistence: localStorage key `cartoTaco_tourCompleted`
@@ -231,6 +234,7 @@ Located in src/lib/dataWrangling.js:
 - `ComparisonTray.svelte` - Floating tray for selecting up to 3 spots for side-by-side comparison
 - `TasteProfile.svelte` - Personal taste profile visualization with archetype display, protein affinities, and scatter plot (heat vs salsa)
 - `TourOverlay.svelte` - Multi-step onboarding tour with targeted tooltips, step highlighting, and next/prev/skip navigation
+- `SummitResults.svelte` - Taco Summit results view: ECharts stacked horizontal bar showing rank distribution per spot (orange gradient), winner callout, dark-mode reactive, optional PNG card download
 
 ### Routes
 - `src/routes/+layout.svelte` - Root layout (Header, theme initialization)
@@ -242,6 +246,8 @@ Located in src/lib/dataWrangling.js:
 #### Public Routes
 - `src/routes/compare/+page.svelte` - Side-by-side comparison of up to 3 spots (shareable via `?ids=1,2,3` query params)
 - `src/routes/compare/+page.js` - Route config for comparison page
+- `src/routes/vote/new/+page.svelte` - Taco Summit creation: pick 2–6 spots, set a title, creates a `group_sessions` row and redirects to the voting page
+- `src/routes/vote/[session_id]/+page.svelte` - Taco Summit voting/results page; states: ranked-choice ballot entry, post-vote waiting with live preview, locked results with `SummitResults`; uses Supabase Realtime for live vote counts and session lock detection; anonymous via `voter_token` UUID in localStorage; creator identified by `creator_token` in localStorage
 
 #### Authentication Routes (`src/routes/(auth)/`)
 - `login/+page.svelte` - Login form

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ An interactive map-based application for exploring taco establishments in Tucson
 - **Taco Trail Route Builder**: Plan multi-stop taco crawls with walking/driving directions via Mapbox Directions API
 - **Spot Comparison Mode**: Compare up to 3 establishments side-by-side with shareable URLs at `/compare`
 - **Taste Profile & Personalization**: k-NN based recommendations from your favorites, 13 taste archetypes
-- **Onboarding Tour**: 7-step guided tour for first-time users
+- **Taco Summit**: Shareable ranked-choice group vote — share a link, everyone ranks their picks, Borda count reveals the winner with a live rank-distribution chart at `/vote/[id]`
+- **Surprise Me**: One-tap random spot selection that respects active filters
+- **Onboarding Tour**: 10-step guided tour for first-time users
 - **Dark Mode**: Light/dark/auto themes with time-based automatic switching
 - **Directions Deep-Link**: Smart links to Apple Maps (iOS), Google Maps (Android), or Google Maps web
 - **New Spots Badge**: Notification badge for recently added establishments

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -458,19 +458,19 @@ See [QUERY_OPTIMIZATION.md](./QUERY_OPTIMIZATION.md), [SEARCH_FILTER.md](./SEARC
 
 ---
 
-### C3. Group Decision Mode
-**Feature**: Generate a shareable voting link for a group. Each recipient votes thumbs up/down on spots. The map highlights the consensus winner in real time as votes come in.
+### C3. Group Decision Mode ✅
+**Status**: Completed (2026-04-02)
 
-**Impact**: Solves the universal "where should we go?" group chat problem. High virality — every group outing is a potential new user acquisition.
-
-**Effort**: Moderate-High (3-5 days)
+**Feature**: Shareable ranked-choice voting link for a group ("Taco Summit"). Each participant drags spots into their preferred order. Borda count tallies the ballots and reveals the winner with an ECharts rank-distribution visualisation.
 
 **Technical Details**:
-- New `group_sessions` table: `id`, `created_by`, `expires_at`, `filter_snapshot`
-- New `group_votes` table: `session_id`, `voter_token`, `est_id`, `vote` (up/down)
-- Shareable URL: `/vote/[session_id]`
-- Real-time vote aggregation via Supabase Realtime
-- Result page highlights winning spot with fly-to on map
+- Migrations 021/022: `group_sessions` and `group_votes` tables with RLS
+- `/vote/new` — creation page: pick 2–6 spots, name the summit, get a shareable link
+- `/vote/[session_id]` — voting/results page with Supabase Realtime subscriptions
+- `SummitResults.svelte` — ECharts stacked horizontal bar (rank distribution per spot) + winner callout; dark-mode reactive
+- Anonymous participation via `voter_token` UUID stored in localStorage
+- Creator identified by `creator_token` stored in localStorage; can lock results
+- "🌮 Summit" button in Header (desktop + mobile) for quick access
 
 ---
 
@@ -565,7 +565,7 @@ See [QUERY_OPTIMIZATION.md](./QUERY_OPTIMIZATION.md), [SEARCH_FILTER.md](./SEARC
 39. **AI menu extraction (#11)** — Advanced automation
 40. **Tucson Taco Index (C1)** — Economic indicator, press-worthy
 41. **Neighborhood Origin Stories (C2)** — Hyper-local storytelling
-42. **Group Decision Mode (C3)** — Viral group UX, solves real problem
+42. ✅ **Group Decision Mode (C3)** — Completed (2026-04-02)
 43. **Community Busyness Reports (C4)** — Real-time crowd signal
 44. **The Midnight Map (C5)** — Late-night discovery, visually striking
 45. **The Anti-Review (C6)** — Richer engagement than star ratings

--- a/migrations/021_create_group_sessions.sql
+++ b/migrations/021_create_group_sessions.sql
@@ -1,0 +1,26 @@
+-- Migration 021: Create group_sessions table for Taco Summit feature
+-- Each session represents a voting round with a set of spots and a shareable link
+
+CREATE TABLE IF NOT EXISTS group_sessions (
+  id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  closed_at     TIMESTAMPTZ,
+  creator_token TEXT        NOT NULL,
+  site_ids      INTEGER[]   NOT NULL,
+  title         TEXT        NOT NULL DEFAULT 'Taco Summit'
+);
+
+-- Enable RLS
+ALTER TABLE group_sessions ENABLE ROW LEVEL SECURITY;
+
+-- Anyone can read sessions (needed to display ballot and results)
+CREATE POLICY "group_sessions_select" ON group_sessions
+  FOR SELECT USING (true);
+
+-- Anyone can create a session (anonymous-friendly)
+CREATE POLICY "group_sessions_insert" ON group_sessions
+  FOR INSERT WITH CHECK (true);
+
+-- Anyone can update a session (creator_token match is enforced in the app query)
+CREATE POLICY "group_sessions_update" ON group_sessions
+  FOR UPDATE USING (true);

--- a/migrations/022_create_group_votes.sql
+++ b/migrations/022_create_group_votes.sql
@@ -1,0 +1,30 @@
+-- Migration 022: Create group_votes table for Taco Summit ranked-choice ballots
+-- Each row is one spot's rank within one voter's ballot for a session
+
+CREATE TABLE IF NOT EXISTS group_votes (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id   UUID        NOT NULL REFERENCES group_sessions(id) ON DELETE CASCADE,
+  voter_token  TEXT        NOT NULL,
+  est_id       INTEGER     NOT NULL,
+  rank         INTEGER     NOT NULL,
+  submitted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(session_id, voter_token, est_id)
+);
+
+-- Index for fast per-session vote fetching
+CREATE INDEX IF NOT EXISTS group_votes_session_id_idx ON group_votes(session_id);
+
+-- Enable RLS
+ALTER TABLE group_votes ENABLE ROW LEVEL SECURITY;
+
+-- Anyone can read votes (results are public/anonymous — no PII stored)
+CREATE POLICY "group_votes_select" ON group_votes
+  FOR SELECT USING (true);
+
+-- Anyone can insert votes
+CREATE POLICY "group_votes_insert" ON group_votes
+  FOR INSERT WITH CHECK (true);
+
+-- Anyone can delete their own votes (voter_token match enforced in app query)
+CREATE POLICY "group_votes_delete" ON group_votes
+  FOR DELETE USING (true);

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -14,29 +14,44 @@ This folder contains SQL migration files for the CartoTaco database.
 
 ## Migration Files
 
-### 001_create_sites_view.sql
-**Purpose**: Creates an optimized database view that combines all site-related tables into a single query.
+Run in order. Each migration depends on the previous ones.
 
-**Impact**:
-- Reduces initial data fetch from 6 separate queries to 1 query
-- Improves page load performance by ~60-70%
-- No changes to application logic required
-
-**Tables Combined**:
-- sites
-- descriptions
-- menu
-- hours
-- salsa
-- protein
-
-**Result**: A new view called `sites_complete` that can be queried just like a regular table.
+| # | File | Purpose |
+|---|------|---------|
+| 001 | `001_create_sites_view.sql` | Creates `sites_complete` view joining all site tables (60–70% faster load) |
+| 002 | `002_add_contact_and_social_fields.sql` | Adds contact/social fields to sites |
+| 003 | `003_create_profiles_table.sql` | Creates user profiles table with RLS (requires Supabase Auth) |
+| 004 | `004_create_location_submissions.sql` | Creates `location_submissions` table for user submissions with RLS |
+| 005 | `005_create_favorites_table.sql` | Creates `user_favorites` table with RLS |
+| 006 | `006_enable_rls_public_tables.sql` | Enables RLS on public tables with read-only policies |
+| 007 | `007_add_created_at_to_sites.sql` | Adds `created_at` timestamp to sites |
+| 008 | `008_update_sites_complete_view.sql` | Updates view to include `created_at` |
+| 009 | `009_add_spec_fk_columns.sql` | Adds FK columns for specialty items |
+| 010 | `010_update_sites_complete_view.sql` | Updates view for spec FK columns |
+| 011 | `011_remove_spec_text_cols_from_view.sql` | Removes legacy text columns from view, keeps FK references |
+| 012 | `012_drop_specialty_item_id_4.sql` | Removes specific specialty item record |
+| 013 | `013_add_burro_perc_to_view.sql` | Adds `burro_perc` to view (fixes burritos in radar chart) |
+| 014 | `014_add_foreign_key_constraints.sql` | Adds FK constraints on `est_id` for child tables |
+| 015 | `015_add_est_id_indexes.sql` | Adds indexes on `est_id` join and spec FK columns |
+| 016 | `016_view_naming_cleanup.sql` | Aliases `burro`→`burrito` in view, removes unused site fields |
+| 017 | `017_drop_legacy_spec_text_columns.sql` | Drops legacy `specialty_item_N` / `protein_spec_N` / `salsa_spec_N` text columns |
+| 018 | `018_rename_spec_fk_columns.sql` | Renames spec FK columns to `spec_id_N` pattern, rebuilds view |
+| 019 | `019_drop_summaries_table.sql` | Drops unused `summaries` table (stats now computed client-side) |
+| 020 | `020_drop_unused_sites_columns.sql` | Drops unused columns from sites (`contact`, `lat_2`, `lon_2`, `days_loc_2`) |
+| 021 | `021_create_group_sessions.sql` | Creates `group_sessions` table for Taco Summit (`id`, `creator_token`, `site_ids`, `title`, `closed_at`) with open RLS |
+| 022 | `022_create_group_votes.sql` | Creates `group_votes` table for ranked-choice ballots (`session_id`, `voter_token`, `est_id`, `rank`) with unique constraint, index, and open RLS |
+| 023 | `023_add_snacks_menu_type.sql` | Adds snacks as a menu type |
 
 ## Rollback
 
-To rollback this migration, run:
+To roll back the `sites_complete` view (migration 001):
 ```sql
 DROP VIEW IF EXISTS public.sites_complete;
 ```
+Then revert `src/lib/stores.js` to use the original 6 separate queries.
 
-Then revert the changes in `src/lib/stores.js` to use the original 6 separate queries.
+To roll back the Taco Summit tables (migrations 021–022):
+```sql
+DROP TABLE IF EXISTS public.group_votes;
+DROP TABLE IF EXISTS public.group_sessions;
+```

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"dotenv": "^16.4.5",
 		"echarts": "^5.5.0",
 		"mapbox-gl": "^3.4.0",
+		"phosphor-svelte": "^3.1.0",
 		"svelte-chartjs": "^3.1.5",
 		"svelte-dnd-action": "^0.9.69",
 		"svg-gauge": "^1.0.7"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"dotenv": "^16.4.5",
 		"echarts": "^5.5.0",
 		"mapbox-gl": "^3.4.0",
-		"phosphor-svelte": "^3.1.0",
+		"phosphor-svelte": "^2.0.1",
 		"svelte-chartjs": "^3.1.5",
 		"svelte-dnd-action": "^0.9.69",
 		"svg-gauge": "^1.0.7"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 		"echarts": "^5.5.0",
 		"mapbox-gl": "^3.4.0",
 		"svelte-chartjs": "^3.1.5",
+		"svelte-dnd-action": "^0.9.69",
 		"svg-gauge": "^1.0.7"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^3.4.0
         version: 3.4.0
       phosphor-svelte:
-        specifier: ^3.1.0
-        version: 3.1.0(svelte@4.2.18)(vite@5.3.2)
+        specifier: ^2.0.1
+        version: 2.0.1(svelte@4.2.18)
       svelte-chartjs:
         specifier: ^3.1.5
         version: 3.1.5(chart.js@4.4.3)(svelte@4.2.18)
@@ -1690,14 +1690,10 @@ packages:
   periscopic@3.1.0:
     resolution: {integrity: sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==}
 
-  phosphor-svelte@3.1.0:
-    resolution: {integrity: sha512-nldtxx+XCgNREvrb7O5xgDsefytXpSkPTx8Rnu3f2qQCUZLDV1rLxYSd2Jcwckuo9lZB1qKMqGR17P4UDC0PrA==}
+  phosphor-svelte@2.0.1:
+    resolution: {integrity: sha512-2Ryvaf1sfCNOF0zTQVghtxOs/6JKn9MV+e9uluNAT9wAosgNYnaBD210WcFGRrva1sF8cddv7EWSS//ITNN4mg==}
     peerDependencies:
-      svelte: ^5.0.0 || ^5.0.0-next.96
-      vite: '>=5'
-    peerDependenciesMeta:
-      vite:
-        optional: true
+      svelte: '>=3'
 
   picocolors@1.0.1:
     resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
@@ -3603,13 +3599,9 @@ snapshots:
       estree-walker: 3.0.3
       is-reference: 3.0.2
 
-  phosphor-svelte@3.1.0(svelte@4.2.18)(vite@5.3.2):
+  phosphor-svelte@2.0.1(svelte@4.2.18):
     dependencies:
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
       svelte: 4.2.18
-    optionalDependencies:
-      vite: 5.3.2
 
   picocolors@1.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       mapbox-gl:
         specifier: ^3.4.0
         version: 3.4.0
+      phosphor-svelte:
+        specifier: ^3.1.0
+        version: 3.1.0(svelte@4.2.18)(vite@5.3.2)
       svelte-chartjs:
         specifier: ^3.1.5
         version: 3.1.5(chart.js@4.4.3)(svelte@4.2.18)
@@ -1687,6 +1690,15 @@ packages:
   periscopic@3.1.0:
     resolution: {integrity: sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==}
 
+  phosphor-svelte@3.1.0:
+    resolution: {integrity: sha512-nldtxx+XCgNREvrb7O5xgDsefytXpSkPTx8Rnu3f2qQCUZLDV1rLxYSd2Jcwckuo9lZB1qKMqGR17P4UDC0PrA==}
+    peerDependencies:
+      svelte: ^5.0.0 || ^5.0.0-next.96
+      vite: '>=5'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
   picocolors@1.0.1:
     resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
@@ -2515,7 +2527,7 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.5':
     dependencies:
       '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.25
 
   '@jridgewell/resolve-uri@3.1.2': {}
@@ -2529,7 +2541,7 @@ snapshots:
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@kurkle/color@0.3.2': {}
 
@@ -2594,7 +2606,7 @@ snapshots:
 
   '@rollup/pluginutils@5.1.0(rollup@4.57.1)':
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 2.3.1
     optionalDependencies:
@@ -2602,7 +2614,7 @@ snapshots:
 
   '@rollup/pluginutils@5.3.0(rollup@4.57.1)':
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.3
     optionalDependencies:
@@ -3070,8 +3082,8 @@ snapshots:
 
   code-red@1.0.4:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
-      '@types/estree': 1.0.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@types/estree': 1.0.8
       acorn: 8.12.0
       estree-walker: 3.0.3
       periscopic: 3.1.0
@@ -3244,7 +3256,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.8
 
   expect-type@1.3.0: {}
 
@@ -3414,7 +3426,7 @@ snapshots:
 
   is-reference@3.0.2:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.8
 
   isexe@2.0.0: {}
 
@@ -3587,9 +3599,17 @@ snapshots:
 
   periscopic@3.1.0:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.8
       estree-walker: 3.0.3
       is-reference: 3.0.2
+
+  phosphor-svelte@3.1.0(svelte@4.2.18)(vite@5.3.2):
+    dependencies:
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+      svelte: 4.2.18
+    optionalDependencies:
+      vite: 5.3.2
 
   picocolors@1.0.1: {}
 
@@ -3781,7 +3801,7 @@ snapshots:
 
   sorcery@0.11.1:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.5
       buffer-crc32: 1.0.0
       minimist: 1.2.8
       sander: 0.5.1
@@ -3871,7 +3891,7 @@ snapshots:
     dependencies:
       '@types/pug': 2.0.10
       detect-indent: 6.1.0
-      magic-string: 0.30.10
+      magic-string: 0.30.21
       sorcery: 0.11.1
       strip-indent: 3.0.0
       svelte: 4.2.18

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       svelte-chartjs:
         specifier: ^3.1.5
         version: 3.1.5(chart.js@4.4.3)(svelte@4.2.18)
+      svelte-dnd-action:
+        specifier: ^0.9.69
+        version: 0.9.69(svelte@4.2.18)
       svg-gauge:
         specifier: ^1.0.7
         version: 1.0.7
@@ -1912,6 +1915,11 @@ packages:
     hasBin: true
     peerDependencies:
       svelte: ^3.55.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0
+
+  svelte-dnd-action@0.9.69:
+    resolution: {integrity: sha512-NAmSOH7htJoYraTQvr+q5whlIuVoq88vEuHr4NcFgscDRUxfWPPxgie2OoxepBCQCikrXZV4pqV86aun60wVyw==}
+    peerDependencies:
+      svelte: '>=3.23.0 || ^5.0.0-next.0'
 
   svelte-hmr@0.16.0:
     resolution: {integrity: sha512-Gyc7cOS3VJzLlfj7wKS0ZnzDVdv3Pn2IuVeJPk9m2skfhcu5bq3wtIZyQGggr7/Iim5rH5cncyQft/kRLupcnA==}
@@ -3850,6 +3858,10 @@ snapshots:
       - sass
       - stylus
       - sugarss
+
+  svelte-dnd-action@0.9.69(svelte@4.2.18):
+    dependencies:
+      svelte: 4.2.18
 
   svelte-hmr@0.16.0(svelte@4.2.18):
     dependencies:

--- a/src/components/FilterBar.svelte
+++ b/src/components/FilterBar.svelte
@@ -2,6 +2,7 @@
   import { filterConfig, filteredTacoData, processedTacoData, flyToTarget } from '../lib/stores';
   import { isAuthenticated } from '$lib/authStore';
   import { SearchOutline, ChevronDownOutline, ChevronUpOutline, HeartSolid } from 'flowbite-svelte-icons';
+  import MagicWand from 'phosphor-svelte/lib/MagicWand.svelte';
   import { browser } from '$app/environment';
   import { trailModeActive, enterTrailMode, exitTrailMode } from '../lib/trailStore.js';
   import { tourExpandFilters } from '$lib/tourStore.js';
@@ -121,7 +122,7 @@
       aria-label="Surprise Me — pick a random spot"
       disabled={$filteredTacoData.length === 0}
     >
-      🌮
+      <MagicWand size={16} weight="duotone" />
       <span class="surprise-text">Surprise Me</span>
     </button>
 

--- a/src/components/FilterBar.svelte
+++ b/src/components/FilterBar.svelte
@@ -2,7 +2,7 @@
   import { filterConfig, filteredTacoData, processedTacoData, flyToTarget } from '../lib/stores';
   import { isAuthenticated } from '$lib/authStore';
   import { SearchOutline, ChevronDownOutline, ChevronUpOutline, HeartSolid } from 'flowbite-svelte-icons';
-  import MagicWand from 'phosphor-svelte/lib/MagicWand.svelte';
+  import MagicWand from 'phosphor-svelte/lib/MagicWand';
   import { browser } from '$app/environment';
   import { trailModeActive, enterTrailMode, exitTrailMode } from '../lib/trailStore.js';
   import { tourExpandFilters } from '$lib/tourStore.js';

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -3,6 +3,7 @@
 	import { goto } from '$app/navigation';
 	import { browser } from '$app/environment';
 	import { BarsOutline, CloseOutline, UserCircleOutline, QuestionCircleOutline } from 'flowbite-svelte-icons';
+	import Ranking from 'phosphor-svelte/lib/Ranking.svelte';
 	import ThemeToggle from './ThemeToggle.svelte';
 	import NewSpotsBadge from './NewSpotsBadge.svelte';
 	import { startTour } from '$lib/tourStore.js';
@@ -56,7 +57,8 @@
         on:click={() => handleNavigation('/vote/new')}
         title="Start a group vote on where to eat"
       >
-        🌮 Summit
+        <Ranking size={16} weight="duotone" />
+        Summit
       </button>
 
       {#if $isAuthenticated}
@@ -148,7 +150,8 @@
         class="mobile-nav-link summit-link"
         on:click={() => handleNavigation('/vote/new')}
       >
-        🌮 Summit — group vote
+        <Ranking size={16} weight="duotone" />
+        Summit — group vote
       </button>
       {#if $isAuthenticated}
         <div class="mobile-user-info">

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -52,6 +52,7 @@
 			</button>
       <button
         class="nav-link summit-link"
+        data-tour="summit"
         on:click={() => handleNavigation('/vote/new')}
         title="Start a group vote on where to eat"
       >

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -3,7 +3,7 @@
 	import { goto } from '$app/navigation';
 	import { browser } from '$app/environment';
 	import { BarsOutline, CloseOutline, UserCircleOutline, QuestionCircleOutline } from 'flowbite-svelte-icons';
-	import Ranking from 'phosphor-svelte/lib/Ranking.svelte';
+	import Ranking from 'phosphor-svelte/lib/Ranking';
 	import ThemeToggle from './ThemeToggle.svelte';
 	import NewSpotsBadge from './NewSpotsBadge.svelte';
 	import { startTour } from '$lib/tourStore.js';

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -50,6 +50,14 @@
 			<button class="help-button" on:click={startTour} title="Take a tour" aria-label="Take a tour">
 				{#if browser}<QuestionCircleOutline size="sm" />{/if}
 			</button>
+      <button
+        class="nav-link summit-link"
+        on:click={() => handleNavigation('/vote/new')}
+        title="Start a group vote on where to eat"
+      >
+        🌮 Summit
+      </button>
+
       {#if $isAuthenticated}
         <div class="user-info">
           {#if browser}
@@ -135,6 +143,12 @@
   <!-- Mobile Menu -->
   {#if $mobileNavOpen}
     <div class="mobile-menu">
+      <button
+        class="mobile-nav-link summit-link"
+        on:click={() => handleNavigation('/vote/new')}
+      >
+        🌮 Summit — group vote
+      </button>
       {#if $isAuthenticated}
         <div class="mobile-user-info">
           {#if browser}
@@ -390,6 +404,23 @@
   .nav-link.sign-out:hover {
     background: #DC2626;
     color: white;
+  }
+
+  .nav-link.summit-link {
+    border-color: rgba(254, 121, 93, 0.4);
+    background: rgba(254, 121, 93, 0.06);
+    font-weight: 600;
+  }
+
+  .nav-link.summit-link:hover {
+    background: rgba(254, 121, 93, 0.14);
+    border-color: #FE795D;
+    color: #FE795D;
+  }
+
+  :global(.dark) .nav-link.summit-link {
+    border-color: rgba(254, 121, 93, 0.3);
+    background: rgba(254, 121, 93, 0.08);
   }
 
   /* Mobile Menu Button */

--- a/src/components/MapStylePicker.svelte
+++ b/src/components/MapStylePicker.svelte
@@ -3,7 +3,7 @@
 	import { browser } from '$app/environment';
 	import { getAvailableStyles, getMapStyle } from '$lib/mapStyles.js';
 	import { MapPinAltOutline } from 'flowbite-svelte-icons';
-	import MapTrifold from 'phosphor-svelte/lib/MapTrifold.svelte';
+	import MapTrifold from 'phosphor-svelte/lib/MapTrifold';
 
 	// Props
 	export let onStyleChange = null;

--- a/src/components/MapStylePicker.svelte
+++ b/src/components/MapStylePicker.svelte
@@ -3,6 +3,7 @@
 	import { browser } from '$app/environment';
 	import { getAvailableStyles, getMapStyle } from '$lib/mapStyles.js';
 	import { MapPinAltOutline } from 'flowbite-svelte-icons';
+	import MapTrifold from 'phosphor-svelte/lib/MapTrifold.svelte';
 
 	// Props
 	export let onStyleChange = null;
@@ -50,7 +51,7 @@
 
 <div class="map-style-picker">
 	<button class="picker-button" on:click={togglePicker} title="Change map style">
-		<span class="map-icon">🗺️</span>
+		<MapTrifold size={18} weight="duotone" />
 		<span class="button-text">{currentStyle.name}</span>
 	</button>
 
@@ -114,11 +115,7 @@
 		color: #fe795d;
 	}
 
-	.map-icon {
-		font-size: 1rem;
-	}
-
-	.button-text {
+.button-text {
 		display: none;
 	}
 

--- a/src/components/SummitResults.svelte
+++ b/src/components/SummitResults.svelte
@@ -12,8 +12,15 @@
   /** Whether the session is closed (finalised results vs live preview) */
   export let locked = false;
 
+  /** Summit title shown on the download card */
+  export let title = 'Taco Summit';
+
+  /** Show the "Download card" button */
+  export let showDownload = false;
+
   let chartContainer;
   let chart;
+  let downloading = false;
 
   // ─── Data computation ─────────────────────────────────────────────────────
 
@@ -151,6 +158,116 @@
     };
   }
 
+  // ─── Download card ────────────────────────────────────────────────────────
+
+  async function downloadCard() {
+    if (!chart || !chartData || downloading) return;
+    downloading = true;
+
+    const isDark = $effectiveTheme === 'dark';
+    const bg = isDark ? '#0a0e1a' : '#ffffff';
+    const textPrimary = isDark ? '#f9fafb' : '#111827';
+    const textMuted = '#9ca3af';
+    const accent = '#FE795D';
+
+    // Render chart to a high-res image with a solid background
+    const chartDataUrl = chart.getDataURL({
+      type: 'png',
+      pixelRatio: 2,
+      backgroundColor: bg,
+    });
+
+    const chartImg = await new Promise((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => resolve(img);
+      img.onerror = reject;
+      img.src = chartDataUrl;
+    });
+
+    // Card dimensions (logical pixels; canvas is 2× for retina)
+    const scale = 2;
+    const cardW = 600;
+    const headerH = 148;
+    const chartH = Math.max(180, chartData.sorted.length * 52 + 60);
+    const footerH = 36;
+    const totalH = headerH + chartH + footerH;
+
+    const canvas = document.createElement('canvas');
+    canvas.width = cardW * scale;
+    canvas.height = totalH * scale;
+    const ctx = canvas.getContext('2d');
+    ctx.scale(scale, scale);
+
+    // Background
+    ctx.fillStyle = bg;
+    ctx.fillRect(0, 0, cardW, totalH);
+
+    // Orange left accent bar
+    ctx.fillStyle = accent;
+    ctx.fillRect(0, 0, 4, totalH);
+
+    // ── Header ──
+    const lx = 20; // left x
+
+    // "TACO SUMMIT RESULTS"
+    ctx.font = 'bold 10px system-ui, -apple-system, sans-serif';
+    ctx.fillStyle = accent;
+    ctx.letterSpacing = '0.08em';
+    ctx.fillText('TACO SUMMIT RESULTS', lx, 26);
+    ctx.letterSpacing = '0';
+
+    // Session title
+    ctx.font = 'bold 22px system-ui, -apple-system, sans-serif';
+    ctx.fillStyle = textPrimary;
+    ctx.fillText(title, lx, 54);
+
+    // "WINNER" label
+    ctx.font = 'bold 10px system-ui, -apple-system, sans-serif';
+    ctx.fillStyle = textMuted;
+    ctx.letterSpacing = '0.06em';
+    ctx.fillText('WINNER', lx, 80);
+    ctx.letterSpacing = '0';
+
+    // Winner name
+    ctx.font = 'bold 18px system-ui, -apple-system, sans-serif';
+    ctx.fillStyle = textPrimary;
+    ctx.fillText(chartData.winner.name, lx, 104);
+
+    // Winner sub-text
+    ctx.font = '12px system-ui, -apple-system, sans-serif';
+    ctx.fillStyle = textMuted;
+    const voterWord = chartData.voterCount === 1 ? 'voter' : 'voters';
+    ctx.fillText(
+      `${chartData.firstChoiceForWinner} of ${chartData.voterCount} ${voterWord} ranked this first`,
+      lx, 124
+    );
+
+    // Divider
+    ctx.fillStyle = isDark ? '#374151' : '#e5e7eb';
+    ctx.fillRect(lx, 138, cardW - lx * 2, 1);
+
+    // ── Chart image ──
+    ctx.drawImage(chartImg, 0, headerH, cardW, chartH);
+
+    // ── Footer ──
+    const fy = totalH - 12;
+    ctx.font = '10px system-ui, -apple-system, sans-serif';
+    ctx.fillStyle = textMuted;
+    const ballotWord = chartData.voterCount === 1 ? 'ballot' : 'ballots';
+    ctx.fillText(
+      `Based on ${chartData.voterCount} ${ballotWord}  ·  cartotaco.com`,
+      lx, fy
+    );
+
+    // Download
+    const link = document.createElement('a');
+    link.download = `taco-summit-${title.toLowerCase().replace(/\s+/g, '-')}.png`;
+    link.href = canvas.toDataURL('image/png');
+    link.click();
+
+    downloading = false;
+  }
+
   // ─── Chart lifecycle ──────────────────────────────────────────────────────
 
   onMount(() => {
@@ -201,10 +318,18 @@
     ></div>
   </div>
 
-  <div class="ballot-footer">
-    Based on {chartData.voterCount} {chartData.voterCount === 1 ? 'ballot' : 'ballots'}
-    {#if !locked}
-      &middot; <span class="live-hint">updating live</span>
+  <div class="results-footer">
+    <span class="ballot-count">
+      Based on {chartData.voterCount} {chartData.voterCount === 1 ? 'ballot' : 'ballots'}
+      {#if !locked}
+        &middot; <span class="live-hint">updating live</span>
+      {/if}
+    </span>
+
+    {#if showDownload && locked}
+      <button class="download-btn" on:click={downloadCard} disabled={downloading}>
+        {downloading ? 'Saving…' : '↓ Download card'}
+      </button>
     {/if}
   </div>
 {:else}
@@ -297,11 +422,49 @@
     width: 100%;
   }
 
-  .ballot-footer {
+  .results-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-top: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .ballot-count {
     font-size: 0.75rem;
     color: #9ca3af;
-    margin-top: 0.5rem;
-    text-align: right;
+  }
+
+  .download-btn {
+    padding: 0.4rem 0.875rem;
+    font-size: 0.78rem;
+    font-weight: 600;
+    background: transparent;
+    border: 1px solid #d1d5db;
+    border-radius: 0.375rem;
+    color: #374151;
+    cursor: pointer;
+    transition: all 0.15s;
+    flex-shrink: 0;
+  }
+
+  .download-btn:hover:not(:disabled) {
+    border-color: #FE795D;
+    color: #FE795D;
+    background: rgba(254, 121, 93, 0.06);
+  }
+
+  .download-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+  :global(.dark) .download-btn {
+    border-color: #4b5563;
+    color: #d1d5db;
+  }
+
+  :global(.dark) .download-btn:hover:not(:disabled) {
+    border-color: #FE795D;
+    color: #FE795D;
   }
 
   .live-hint {

--- a/src/components/SummitResults.svelte
+++ b/src/components/SummitResults.svelte
@@ -2,6 +2,8 @@
   import { onMount } from 'svelte';
   import * as echarts from 'echarts';
   import { effectiveTheme } from '$lib/theme.js';
+  import Trophy from 'phosphor-svelte/lib/Trophy.svelte';
+  import ChartBar from 'phosphor-svelte/lib/ChartBar.svelte';
 
   /** @type {{ voter_token: string, est_id: number, rank: number }[]} */
   export let votes = [];
@@ -297,7 +299,7 @@
 {#if chartData}
   <!-- Winner callout -->
   <div class="winner-card" class:locked>
-    <span class="trophy" aria-hidden="true">{locked ? '🌮' : '📊'}</span>
+    <span class="trophy" aria-hidden="true">{#if locked}<Trophy size={28} weight="duotone" />{:else}<ChartBar size={28} weight="duotone" />{/if}</span>
     <div class="winner-body">
       <div class="winner-label">{locked ? 'Summit Winner!' : 'Current Leader'}</div>
       <div class="winner-name">{chartData.winner.name}</div>

--- a/src/components/SummitResults.svelte
+++ b/src/components/SummitResults.svelte
@@ -2,8 +2,8 @@
   import { onMount } from 'svelte';
   import * as echarts from 'echarts';
   import { effectiveTheme } from '$lib/theme.js';
-  import Trophy from 'phosphor-svelte/lib/Trophy.svelte';
-  import ChartBar from 'phosphor-svelte/lib/ChartBar.svelte';
+  import Trophy from 'phosphor-svelte/lib/Trophy';
+  import ChartBar from 'phosphor-svelte/lib/ChartBar';
 
   /** @type {{ voter_token: string, est_id: number, rank: number }[]} */
   export let votes = [];

--- a/src/components/SummitResults.svelte
+++ b/src/components/SummitResults.svelte
@@ -1,0 +1,319 @@
+<script>
+  import { onMount } from 'svelte';
+  import * as echarts from 'echarts';
+  import { effectiveTheme } from '$lib/theme.js';
+
+  /** @type {{ voter_token: string, est_id: number, rank: number }[]} */
+  export let votes = [];
+
+  /** @type {import('$lib/stores').ProcessedSite[]} */
+  export let sites = [];
+
+  /** Whether the session is closed (finalised results vs live preview) */
+  export let locked = false;
+
+  let chartContainer;
+  let chart;
+
+  // ─── Data computation ─────────────────────────────────────────────────────
+
+  function prepareChartData(votes, sites) {
+    const n = sites.length;
+    if (n === 0 || votes.length === 0) return null;
+
+    const voterSet = new Set(votes.map(v => v.voter_token));
+    const voterCount = voterSet.size;
+
+    // Rank distribution: distribution[estId][rank] = count
+    const distribution = {};
+    sites.forEach(s => {
+      distribution[s.est_id] = {};
+      for (let r = 1; r <= n; r++) distribution[s.est_id][r] = 0;
+    });
+    votes.forEach(v => {
+      if (distribution[v.est_id] !== undefined) {
+        distribution[v.est_id][v.rank] = (distribution[v.est_id][v.rank] || 0) + 1;
+      }
+    });
+
+    // Borda scores: n points for 1st, n-1 for 2nd, … per ballot
+    const bordaScores = Object.fromEntries(sites.map(s => [s.est_id, 0]));
+    const byVoter = {};
+    votes.forEach(v => {
+      (byVoter[v.voter_token] ??= []).push(v);
+    });
+    Object.values(byVoter).forEach(ballot => {
+      const sorted = [...ballot].sort((a, b) => a.rank - b.rank);
+      sorted.forEach((v, i) => { bordaScores[v.est_id] += (n - i); });
+    });
+
+    // Sort ascending — ECharts horizontal bar renders bottom→top,
+    // so lowest score first means the winner appears at the top visually.
+    const sorted = [...sites].sort((a, b) => bordaScores[a.est_id] - bordaScores[b.est_id]);
+
+    const winner = sorted[sorted.length - 1];
+    const firstChoiceForWinner = distribution[winner.est_id][1];
+
+    return { sorted, distribution, bordaScores, voterCount, winner, firstChoiceForWinner, n };
+  }
+
+  $: chartData = prepareChartData(votes, sites);
+
+  // ─── ECharts config ───────────────────────────────────────────────────────
+
+  /** Orange gradient: 1st choice = brand orange, last choice = near-white / near-dark */
+  function rankColors(n, isDark) {
+    const base = [254, 121, 93]; // #FE795D
+    const end = isDark ? [55, 65, 81] : [229, 231, 235]; // #374151 / #E5E7EB
+    return Array.from({ length: n }, (_, i) => {
+      const t = n === 1 ? 0 : i / (n - 1);
+      const r = Math.round(base[0] + (end[0] - base[0]) * t);
+      const g = Math.round(base[1] + (end[1] - base[1]) * t);
+      const b = Math.round(base[2] + (end[2] - base[2]) * t);
+      return `rgb(${r},${g},${b})`;
+    });
+  }
+
+  function rankLabel(rank) {
+    if (rank === 1) return '1st choice';
+    if (rank === 2) return '2nd choice';
+    if (rank === 3) return '3rd choice';
+    return `${rank}th choice`;
+  }
+
+  function buildOption(data, isDark) {
+    const { sorted, distribution, n, voterCount } = data;
+    const colors = rankColors(n, isDark);
+    const textColor = isDark ? '#f9fafb' : '#1f2937';
+    const gridColor = isDark ? '#374151' : '#e5e7eb';
+
+    const series = Array.from({ length: n }, (_, i) => {
+      const rank = i + 1;
+      return {
+        name: rankLabel(rank),
+        type: 'bar',
+        stack: 'total',
+        barMaxWidth: 36,
+        data: sorted.map(s => distribution[s.est_id][rank] || 0),
+        itemStyle: {
+          color: colors[i],
+          borderRadius: i === n - 1 ? [0, 4, 4, 0] : 0,
+        },
+        label: {
+          show: rank === 1,
+          position: 'inside',
+          formatter: p => p.value > 0 ? String(p.value) : '',
+          color: '#fff',
+          fontSize: 11,
+          fontWeight: 600,
+        },
+      };
+    });
+
+    return {
+      backgroundColor: 'transparent',
+      tooltip: {
+        trigger: 'axis',
+        axisPointer: { type: 'shadow' },
+        formatter: params => {
+          const spotName = sorted[params[0].dataIndex].name;
+          const lines = params
+            .filter(p => p.value > 0)
+            .map(p => `${p.marker}${p.seriesName}: <b>${p.value}</b>`);
+          return `<b>${spotName}</b><br/>${lines.join('<br/>')}`;
+        },
+      },
+      legend: {
+        bottom: 0,
+        textStyle: { color: textColor, fontSize: 11 },
+        itemWidth: 12,
+        itemHeight: 12,
+      },
+      grid: { left: 8, right: 16, top: 8, bottom: 48, containLabel: true },
+      xAxis: {
+        type: 'value',
+        max: voterCount,
+        minInterval: 1,
+        splitLine: { lineStyle: { color: gridColor } },
+        axisLabel: { color: textColor, fontSize: 11 },
+      },
+      yAxis: {
+        type: 'category',
+        data: sorted.map(s => s.name),
+        axisLabel: {
+          color: textColor,
+          fontSize: 12,
+          overflow: 'truncate',
+          width: 130,
+        },
+      },
+      series,
+    };
+  }
+
+  // ─── Chart lifecycle ──────────────────────────────────────────────────────
+
+  onMount(() => {
+    function initChart() {
+      if (!chartContainer || chartContainer.clientWidth === 0) {
+        requestAnimationFrame(initChart);
+        return;
+      }
+      chart = echarts.init(chartContainer);
+      if (chartData) {
+        chart.setOption(buildOption(chartData, $effectiveTheme === 'dark'));
+      }
+    }
+    initChart();
+    return () => { if (chart) chart.dispose(); };
+  });
+
+  // Re-render when data or theme changes
+  $: if (chart && chartData) {
+    chart.setOption(buildOption(chartData, $effectiveTheme === 'dark'), true);
+  }
+
+  // Chart height scales with number of spots
+  $: chartHeight = Math.max(180, sites.length * 52);
+</script>
+
+{#if chartData}
+  <!-- Winner callout -->
+  <div class="winner-card" class:locked>
+    <span class="trophy" aria-hidden="true">{locked ? '🌮' : '📊'}</span>
+    <div class="winner-body">
+      <div class="winner-label">{locked ? 'Summit Winner!' : 'Current Leader'}</div>
+      <div class="winner-name">{chartData.winner.name}</div>
+      <div class="winner-sub">
+        {chartData.firstChoiceForWinner} of {chartData.voterCount}
+        {chartData.voterCount === 1 ? 'voter' : 'voters'} ranked this first
+      </div>
+    </div>
+  </div>
+
+  <!-- Chart -->
+  <div class="chart-section">
+    <div class="chart-title">How the group ranked it</div>
+    <div
+      bind:this={chartContainer}
+      class="chart-container"
+      style="height: {chartHeight}px;"
+    ></div>
+  </div>
+
+  <div class="ballot-footer">
+    Based on {chartData.voterCount} {chartData.voterCount === 1 ? 'ballot' : 'ballots'}
+    {#if !locked}
+      &middot; <span class="live-hint">updating live</span>
+    {/if}
+  </div>
+{:else}
+  <div class="empty-state">No votes yet — be the first to rank!</div>
+{/if}
+
+<style>
+  .winner-card {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.875rem;
+    padding: 1rem 1.25rem;
+    border-left: 4px solid #FE795D;
+    background: rgba(254, 121, 93, 0.07);
+    border-radius: 0 0.5rem 0.5rem 0;
+    margin-bottom: 1.25rem;
+  }
+
+  .winner-card.locked {
+    background: rgba(254, 121, 93, 0.13);
+  }
+
+  :global(.dark) .winner-card {
+    background: rgba(254, 121, 93, 0.1);
+  }
+
+  :global(.dark) .winner-card.locked {
+    background: rgba(254, 121, 93, 0.18);
+  }
+
+  .trophy {
+    font-size: 1.75rem;
+    line-height: 1;
+    flex-shrink: 0;
+    margin-top: 0.1rem;
+  }
+
+  .winner-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+
+  .winner-label {
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #FE795D;
+  }
+
+  .winner-name {
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: #111827;
+    line-height: 1.2;
+  }
+
+  :global(.dark) .winner-name {
+    color: #f9fafb;
+  }
+
+  .winner-sub {
+    font-size: 0.8rem;
+    color: #6b7280;
+  }
+
+  :global(.dark) .winner-sub {
+    color: #9ca3af;
+  }
+
+  .chart-section {
+    margin-bottom: 0.5rem;
+  }
+
+  .chart-title {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: #6b7280;
+    margin-bottom: 0.5rem;
+  }
+
+  :global(.dark) .chart-title {
+    color: #9ca3af;
+  }
+
+  .chart-container {
+    width: 100%;
+  }
+
+  .ballot-footer {
+    font-size: 0.75rem;
+    color: #9ca3af;
+    margin-top: 0.5rem;
+    text-align: right;
+  }
+
+  .live-hint {
+    color: #FE795D;
+    font-weight: 500;
+  }
+
+  .empty-state {
+    padding: 1.5rem;
+    text-align: center;
+    color: #9ca3af;
+    font-style: italic;
+    font-size: 0.9rem;
+  }
+</style>

--- a/src/components/TrailTray.svelte
+++ b/src/components/TrailTray.svelte
@@ -12,11 +12,11 @@
     fetchRoute,
     addLocationStop
   } from '../lib/trailStore.js';
-  import PersonSimpleWalk from 'phosphor-svelte/lib/PersonSimpleWalk.svelte';
-  import CarProfile from 'phosphor-svelte/lib/CarProfile.svelte';
-  import MapPin from 'phosphor-svelte/lib/MapPin.svelte';
-  import SpinnerGap from 'phosphor-svelte/lib/SpinnerGap.svelte';
-  import ShareNetwork from 'phosphor-svelte/lib/ShareNetwork.svelte';
+  import PersonSimpleWalk from 'phosphor-svelte/lib/PersonSimpleWalk';
+  import CarProfile from 'phosphor-svelte/lib/CarProfile';
+  import MapPin from 'phosphor-svelte/lib/MapPin';
+  import SpinnerGap from 'phosphor-svelte/lib/SpinnerGap';
+  import ShareNetwork from 'phosphor-svelte/lib/ShareNetwork';
 
   // --- My Location ---
   let locatingStart = false;

--- a/src/components/TrailTray.svelte
+++ b/src/components/TrailTray.svelte
@@ -12,6 +12,11 @@
     fetchRoute,
     addLocationStop
   } from '../lib/trailStore.js';
+  import PersonSimpleWalk from 'phosphor-svelte/lib/PersonSimpleWalk.svelte';
+  import CarProfile from 'phosphor-svelte/lib/CarProfile.svelte';
+  import MapPin from 'phosphor-svelte/lib/MapPin.svelte';
+  import SpinnerGap from 'phosphor-svelte/lib/SpinnerGap.svelte';
+  import ShareNetwork from 'phosphor-svelte/lib/ShareNetwork.svelte';
 
   // --- My Location ---
   let locatingStart = false;
@@ -148,7 +153,7 @@
         aria-label="Walking mode"
         title="Walking"
       >
-        🚶 Walk
+        <PersonSimpleWalk size={15} weight="bold" /> Walk
       </button>
       <button
         class="mode-btn"
@@ -157,7 +162,7 @@
         aria-label="Driving mode"
         title="Driving"
       >
-        🚗 Drive
+        <CarProfile size={15} weight="bold" /> Drive
       </button>
     </div>
 
@@ -174,7 +179,7 @@
       disabled={locatingStart || locatingEnd}
       title="Use current location as first stop"
     >
-      {locatingStart ? '⏳ Locating…' : '📍 Start Here'}
+      {#if locatingStart}<SpinnerGap size={14} class="spin" /> Locating…{:else}<MapPin size={14} weight="fill" /> Start Here{/if}
     </button>
     <button
       class="loc-btn"
@@ -182,7 +187,7 @@
       disabled={locatingStart || locatingEnd}
       title="Use current location as last stop"
     >
-      {locatingEnd ? '⏳ Locating…' : '📍 End Here'}
+      {#if locatingEnd}<SpinnerGap size={14} class="spin" /> Locating…{:else}<MapPin size={14} weight="fill" /> End Here{/if}
     </button>
   </div>
   {#if locationError}
@@ -248,7 +253,7 @@
       on:click={shareTrail}
       title={canAct ? 'Copy shareable link' : 'Add at least 2 stops'}
     >
-      {copied ? '✓ Copied!' : 'Share Trail 🔗'}
+      <ShareNetwork size={15} weight="bold" /> {copied ? 'Copied!' : 'Share Trail'}
     </button>
   </div>
 </div>

--- a/src/lib/tourStore.js
+++ b/src/lib/tourStore.js
@@ -40,6 +40,13 @@ export const TOUR_STEPS = [
 		description: 'Plan a multi-stop taco crawl! Click spots on the map to add them to your route.'
 	},
 	{
+		id: 'summit',
+		target: '[data-tour="summit"]',
+		title: 'Settle It with a Taco Summit 🌮',
+		description: "Can't agree on where to eat? Start a Summit — share a link, everyone ranks their picks, and the app tallies the votes. Anonymous, instant, and actually fun.",
+		cta: { label: 'Start a Summit', href: '/vote/new' }
+	},
+	{
 		id: 'map',
 		target: null,
 		title: 'Explore the Map',

--- a/src/routes/(protected)/favorites/+page.svelte
+++ b/src/routes/(protected)/favorites/+page.svelte
@@ -3,6 +3,7 @@
 	import { goto } from '$app/navigation';
 	import { browser } from '$app/environment';
 	import { HeartSolid, MapPinAltSolid } from 'flowbite-svelte-icons';
+	import HeartBreak from 'phosphor-svelte/lib/HeartBreak.svelte';
 	import { favoriteIds, loadFavorites } from '$lib/favoritesStore';
 	import { processedTacoData } from '$lib/stores';
 	import FavoriteButton from '../../../components/FavoriteButton.svelte';
@@ -59,7 +60,7 @@
 		{:else if favoriteLocations.length === 0}
 			<!-- Empty State -->
 			<div class="empty-state">
-				<div class="empty-icon">💔</div>
+				<div class="empty-icon"><HeartBreak size={64} weight="duotone" /></div>
 				<h2>No favorites yet</h2>
 				<p>Start exploring the map and save your favorite taco spots!</p>
 				<button class="explore-button" on:click={() => goto('/')}>
@@ -232,8 +233,8 @@
 	}
 
 	.empty-icon {
-		font-size: 4rem;
 		margin-bottom: 1rem;
+		color: #fe795d;
 	}
 
 	.empty-state h2 {

--- a/src/routes/(protected)/favorites/+page.svelte
+++ b/src/routes/(protected)/favorites/+page.svelte
@@ -3,7 +3,7 @@
 	import { goto } from '$app/navigation';
 	import { browser } from '$app/environment';
 	import { HeartSolid, MapPinAltSolid } from 'flowbite-svelte-icons';
-	import HeartBreak from 'phosphor-svelte/lib/HeartBreak.svelte';
+	import HeartBreak from 'phosphor-svelte/lib/HeartBreak';
 	import { favoriteIds, loadFavorites } from '$lib/favoritesStore';
 	import { processedTacoData } from '$lib/stores';
 	import FavoriteButton from '../../../components/FavoriteButton.svelte';

--- a/src/routes/vote/[session_id]/+page.js
+++ b/src/routes/vote/[session_id]/+page.js
@@ -1,0 +1,1 @@
+export const prerender = false;

--- a/src/routes/vote/[session_id]/+page.svelte
+++ b/src/routes/vote/[session_id]/+page.svelte
@@ -496,7 +496,7 @@
     padding: 0.5rem 0.75rem;
     border: 1px solid #d1d5db;
     border-radius: 0.375rem;
-    font-size: 0.8rem;
+    font-size: 1rem; /* 16px min prevents iOS Safari auto-zoom on focus */
     color: #374151;
     background: white;
   }

--- a/src/routes/vote/[session_id]/+page.svelte
+++ b/src/routes/vote/[session_id]/+page.svelte
@@ -313,7 +313,7 @@
             on:consider={handleDndConsider}
             on:finalize={handleDndFinalize}
           >
-            {#each rankedSpots as spot, i (spot.est_id)}
+            {#each rankedSpots as spot, i (spot.id)}
               <li class="ballot-item">
                 <span class="drag-handle" aria-hidden="true">⠿</span>
                 <span class="rank-num">{i + 1}</span>

--- a/src/routes/vote/[session_id]/+page.svelte
+++ b/src/routes/vote/[session_id]/+page.svelte
@@ -48,7 +48,8 @@
   let ballotReady = false;
 
   $: if (!ballotReady && sessionSites.length > 0) {
-    rankedSpots = [...sessionSites];
+    // svelte-dnd-action requires items to have an `id` field (no keyField option)
+    rankedSpots = sessionSites.map(s => ({ ...s, id: s.est_id }));
     ballotReady = true;
   }
 
@@ -308,7 +309,7 @@
 
           <ol
             class="ballot-list"
-            use:dndzone={{ items: rankedSpots, keyField: 'est_id' }}
+            use:dndzone={{ items: rankedSpots }}
             on:consider={handleDndConsider}
             on:finalize={handleDndFinalize}
           >

--- a/src/routes/vote/[session_id]/+page.svelte
+++ b/src/routes/vote/[session_id]/+page.svelte
@@ -6,7 +6,7 @@
   import { processedTacoData, isLoading } from '$lib/stores.js';
   import { supabaseBrowser } from '$lib/supabaseBrowser.js';
   import SummitResults from '../../../components/SummitResults.svelte';
-  import { dndzone, SHADOW_ITEM_MARKER_PROPERTY_NAME } from 'svelte-dnd-action';
+  import { dndzone } from 'svelte-dnd-action';
 
   $: sessionId = $page.params.session_id;
 
@@ -52,9 +52,10 @@
     ballotReady = true;
   }
 
-  // dndzone requires items with an `id` field; we use est_id as the key
-  $: dndItems = rankedSpots.map(s => ({ ...s, id: s.est_id }));
-
+  // svelte-dnd-action: use rankedSpots directly with keyField so there is no
+  // derived array between the zone and the source of truth. A derived array
+  // causes a reactive recompute on every consider event, which resets the
+  // drag state mid-drag and makes items disappear.
   function handleDndConsider(e) {
     rankedSpots = e.detail.items;
   }
@@ -307,11 +308,11 @@
 
           <ol
             class="ballot-list"
-            use:dndzone={{ items: dndItems, keyField: 'id' }}
+            use:dndzone={{ items: rankedSpots, keyField: 'est_id' }}
             on:consider={handleDndConsider}
             on:finalize={handleDndFinalize}
           >
-            {#each dndItems as spot, i (spot.id)}
+            {#each rankedSpots as spot, i (spot.est_id)}
               <li class="ballot-item">
                 <span class="drag-handle" aria-hidden="true">⠿</span>
                 <span class="rank-num">{i + 1}</span>

--- a/src/routes/vote/[session_id]/+page.svelte
+++ b/src/routes/vote/[session_id]/+page.svelte
@@ -6,6 +6,7 @@
   import { processedTacoData, isLoading } from '$lib/stores.js';
   import { supabaseBrowser } from '$lib/supabaseBrowser.js';
   import SummitResults from '../../../components/SummitResults.svelte';
+  import { dndzone, SHADOW_ITEM_MARKER_PROPERTY_NAME } from 'svelte-dnd-action';
 
   $: sessionId = $page.params.session_id;
 
@@ -49,6 +50,17 @@
   $: if (!ballotReady && sessionSites.length > 0) {
     rankedSpots = [...sessionSites];
     ballotReady = true;
+  }
+
+  // dndzone requires items with an `id` field; we use est_id as the key
+  $: dndItems = rankedSpots.map(s => ({ ...s, id: s.est_id }));
+
+  function handleDndConsider(e) {
+    rankedSpots = e.detail.items;
+  }
+
+  function handleDndFinalize(e) {
+    rankedSpots = e.detail.items;
   }
 
   function moveUp(index) {
@@ -271,7 +283,7 @@
 
       <!-- ── RESULTS (locked) ── -->
       {#if isLocked}
-        <SummitResults {votes} sites={sessionSites} locked={true} />
+        <SummitResults {votes} sites={sessionSites} locked={true} title={session.title} showDownload={true} />
 
       <!-- ── VOTED ALREADY (open) ── -->
       {:else if hasVoted}
@@ -284,18 +296,24 @@
         </div>
         <!-- Live preview while waiting -->
         {#if votes.length > 0}
-          <SummitResults {votes} sites={sessionSites} locked={false} />
+          <SummitResults {votes} sites={sessionSites} locked={false} title={session.title} />
         {/if}
 
       <!-- ── BALLOT (open, not yet voted) ── -->
       {:else}
         <div class="ballot-section">
           <h2 class="ballot-heading">Rank the spots</h2>
-          <p class="ballot-sub">Drag them into your preferred order using the arrows. #1 is your top pick.</p>
+          <p class="ballot-sub">Drag to reorder, or use the arrows. #1 is your top pick.</p>
 
-          <ol class="ballot-list">
-            {#each rankedSpots as spot, i (spot.est_id)}
+          <ol
+            class="ballot-list"
+            use:dndzone={{ items: dndItems, keyField: 'id' }}
+            on:consider={handleDndConsider}
+            on:finalize={handleDndFinalize}
+          >
+            {#each dndItems as spot, i (spot.id)}
               <li class="ballot-item">
+                <span class="drag-handle" aria-hidden="true">⠿</span>
                 <span class="rank-num">{i + 1}</span>
                 <div class="ballot-arrows">
                   <button
@@ -622,6 +640,17 @@
     border-bottom-color: #374151;
   }
   .ballot-item:last-child { border-bottom: none; }
+
+  .drag-handle {
+    color: #9ca3af;
+    font-size: 1.1rem;
+    cursor: grab;
+    flex-shrink: 0;
+    user-select: none;
+    padding: 0 2px;
+  }
+  .drag-handle:active { cursor: grabbing; }
+  :global(.dark) .drag-handle { color: #6b7280; }
 
   .rank-num {
     font-size: 1rem;

--- a/src/routes/vote/[session_id]/+page.svelte
+++ b/src/routes/vote/[session_id]/+page.svelte
@@ -1,0 +1,722 @@
+<script>
+  import { page } from '$app/stores';
+  import { goto } from '$app/navigation';
+  import { browser } from '$app/environment';
+  import { onMount, onDestroy } from 'svelte';
+  import { processedTacoData, isLoading } from '$lib/stores.js';
+  import { supabaseBrowser } from '$lib/supabaseBrowser.js';
+  import SummitResults from '../../../components/SummitResults.svelte';
+
+  $: sessionId = $page.params.session_id;
+
+  // ─── State ────────────────────────────────────────────────────────────────
+
+  let session = null;       // group_sessions row
+  let votes = [];           // group_votes rows for this session
+  let loadError = '';
+  let dataLoading = true;
+
+  // The spots in this session, in processedTacoData form
+  $: sessionSites = session
+    ? (session.site_ids || [])
+        .map(id => $processedTacoData.find(s => s.est_id === id))
+        .filter(Boolean)
+    : [];
+
+  // Whether the session is closed
+  $: isLocked = !!session?.closed_at;
+
+  // Voter identity stored in localStorage
+  let voterToken = '';
+  let creatorToken = '';
+
+  $: isCreator = !!(creatorToken && session?.creator_token === creatorToken);
+
+  // Has this browser already voted?
+  $: hasVoted = voterToken
+    ? votes.some(v => v.voter_token === voterToken)
+    : false;
+
+  // Distinct voter count
+  $: voterCount = new Set(votes.map(v => v.voter_token)).size;
+
+  // ─── Ballot state (ranked list for voting UI) ─────────────────────────────
+
+  // rankedSpots is the ordered list the user is building; starts in session order
+  let rankedSpots = [];
+  let ballotReady = false;
+
+  $: if (!ballotReady && sessionSites.length > 0) {
+    rankedSpots = [...sessionSites];
+    ballotReady = true;
+  }
+
+  function moveUp(index) {
+    if (index === 0) return;
+    const next = [...rankedSpots];
+    [next[index - 1], next[index]] = [next[index], next[index - 1]];
+    rankedSpots = next;
+  }
+
+  function moveDown(index) {
+    if (index === rankedSpots.length - 1) return;
+    const next = [...rankedSpots];
+    [next[index], next[index + 1]] = [next[index + 1], next[index]];
+    rankedSpots = next;
+  }
+
+  // ─── Submitting a ballot ──────────────────────────────────────────────────
+
+  let submitting = false;
+  let submitError = '';
+
+  async function submitBallot() {
+    if (!browser || submitting || !voterToken) return;
+    submitting = true;
+    submitError = '';
+
+    // Delete any previous votes from this voter (allows re-voting while session is open)
+    await supabaseBrowser
+      .from('group_votes')
+      .delete()
+      .eq('session_id', sessionId)
+      .eq('voter_token', voterToken);
+
+    // Insert one row per spot with the voter's ranking
+    const rows = rankedSpots.map((spot, i) => ({
+      session_id: sessionId,
+      voter_token: voterToken,
+      est_id: spot.est_id,
+      rank: i + 1,
+    }));
+
+    const { error } = await supabaseBrowser.from('group_votes').insert(rows);
+
+    if (error) {
+      submitError = 'Could not save your vote. Please try again.';
+      submitting = false;
+      return;
+    }
+
+    // Mark as voted in localStorage
+    localStorage.setItem(`summit_voted_${sessionId}`, '1');
+    submitting = false;
+    await loadVotes();
+  }
+
+  // ─── Locking the session ──────────────────────────────────────────────────
+
+  let locking = false;
+
+  async function lockSession() {
+    if (!isCreator || locking) return;
+    locking = true;
+    const { error } = await supabaseBrowser
+      .from('group_sessions')
+      .update({ closed_at: new Date().toISOString() })
+      .eq('id', sessionId)
+      .eq('creator_token', creatorToken);
+    if (error) { locking = false; }
+    // Realtime will update session; also reload just in case
+    await loadSession();
+    locking = false;
+  }
+
+  // ─── Copying the share link ───────────────────────────────────────────────
+
+  let copied = false;
+  async function copyLink() {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      copied = true;
+      setTimeout(() => { copied = false; }, 2500);
+    } catch { /* silent */ }
+  }
+
+  // ─── Data loading ─────────────────────────────────────────────────────────
+
+  async function loadSession() {
+    const { data, error } = await supabaseBrowser
+      .from('group_sessions')
+      .select('*')
+      .eq('id', sessionId)
+      .single();
+    if (error || !data) {
+      loadError = 'Summit not found.';
+    } else {
+      session = data;
+    }
+  }
+
+  async function loadVotes() {
+    const { data } = await supabaseBrowser
+      .from('group_votes')
+      .select('voter_token, est_id, rank')
+      .eq('session_id', sessionId);
+    votes = data || [];
+  }
+
+  // ─── Realtime subscriptions ───────────────────────────────────────────────
+
+  let votesChannel;
+  let sessionChannel;
+
+  function subscribeRealtime() {
+    votesChannel = supabaseBrowser
+      .channel(`summit-votes-${sessionId}`)
+      .on('postgres_changes', {
+        event: '*',
+        schema: 'public',
+        table: 'group_votes',
+        filter: `session_id=eq.${sessionId}`,
+      }, () => loadVotes())
+      .subscribe();
+
+    sessionChannel = supabaseBrowser
+      .channel(`summit-session-${sessionId}`)
+      .on('postgres_changes', {
+        event: 'UPDATE',
+        schema: 'public',
+        table: 'group_sessions',
+        filter: `id=eq.${sessionId}`,
+      }, payload => { session = payload.new; })
+      .subscribe();
+  }
+
+  // ─── Lifecycle ────────────────────────────────────────────────────────────
+
+  onMount(async () => {
+    if (!browser) return;
+
+    // Restore voter / creator tokens from localStorage
+    voterToken = localStorage.getItem(`summit_voter_${sessionId}`) || (() => {
+      const t = crypto.randomUUID();
+      localStorage.setItem(`summit_voter_${sessionId}`, t);
+      return t;
+    })();
+
+    creatorToken = localStorage.getItem(`summit_creator_${sessionId}`) || '';
+
+    await Promise.all([loadSession(), loadVotes()]);
+    dataLoading = false;
+    subscribeRealtime();
+  });
+
+  onDestroy(() => {
+    votesChannel?.unsubscribe();
+    sessionChannel?.unsubscribe();
+  });
+</script>
+
+<div class="page">
+  <div class="container">
+    <button class="back-btn" on:click={() => goto('/')}>&larr; Back to Map</button>
+
+    {#if dataLoading || $isLoading}
+      <div class="status-msg">Loading summit…</div>
+
+    {:else if loadError}
+      <div class="error-block">
+        <div class="error-icon">🌮</div>
+        <p>{loadError}</p>
+        <button class="create-btn-sm" on:click={() => goto('/vote/new')}>Start a new summit</button>
+      </div>
+
+    {:else if session}
+      <!-- Session header -->
+      <div class="session-header">
+        <h1 class="session-title">{session.title}</h1>
+        {#if isLocked}
+          <span class="badge badge-locked">Results locked</span>
+        {:else}
+          <span class="badge badge-open">Voting open</span>
+        {/if}
+      </div>
+
+      <!-- ── CREATOR CONTROLS (open session) ── -->
+      {#if isCreator && !isLocked}
+        <div class="creator-panel">
+          <p class="creator-label">You created this summit</p>
+          <div class="share-row">
+            <input
+              type="text"
+              readonly
+              class="share-input"
+              value={browser ? window.location.href : ''}
+            />
+            <button class="copy-btn" on:click={copyLink}>
+              {copied ? 'Copied!' : 'Copy link'}
+            </button>
+          </div>
+          <div class="creator-footer">
+            <span class="voter-count">{voterCount} {voterCount === 1 ? 'vote' : 'votes'} so far</span>
+            <button
+              class="lock-btn"
+              disabled={locking || voterCount === 0}
+              on:click={lockSession}
+              title={voterCount === 0 ? 'Wait for at least one vote before locking' : 'Lock and reveal results'}
+            >
+              {locking ? 'Locking…' : 'Lock & reveal results'}
+            </button>
+          </div>
+        </div>
+      {/if}
+
+      <!-- ── SHARE NUDGE (non-creator, open) ── -->
+      {#if !isCreator && !isLocked && !hasVoted}
+        <div class="share-nudge">
+          Share this page with your crew so they can vote too.
+        </div>
+      {/if}
+
+      <!-- ── RESULTS (locked) ── -->
+      {#if isLocked}
+        <SummitResults {votes} sites={sessionSites} locked={true} />
+
+      <!-- ── VOTED ALREADY (open) ── -->
+      {:else if hasVoted}
+        <div class="voted-banner">
+          <span class="voted-icon">✓</span>
+          <div>
+            <div class="voted-title">Your ballot is in!</div>
+            <div class="voted-sub">Waiting for the creator to lock the results.</div>
+          </div>
+        </div>
+        <!-- Live preview while waiting -->
+        {#if votes.length > 0}
+          <SummitResults {votes} sites={sessionSites} locked={false} />
+        {/if}
+
+      <!-- ── BALLOT (open, not yet voted) ── -->
+      {:else}
+        <div class="ballot-section">
+          <h2 class="ballot-heading">Rank the spots</h2>
+          <p class="ballot-sub">Drag them into your preferred order using the arrows. #1 is your top pick.</p>
+
+          <ol class="ballot-list">
+            {#each rankedSpots as spot, i (spot.est_id)}
+              <li class="ballot-item">
+                <span class="rank-num">{i + 1}</span>
+                <div class="ballot-arrows">
+                  <button
+                    class="arrow-btn"
+                    disabled={i === 0}
+                    on:click={() => moveUp(i)}
+                    aria-label="Move up"
+                  >▲</button>
+                  <button
+                    class="arrow-btn"
+                    disabled={i === rankedSpots.length - 1}
+                    on:click={() => moveDown(i)}
+                    aria-label="Move down"
+                  >▼</button>
+                </div>
+                <div class="ballot-spot-info">
+                  <span class="ballot-spot-name">{spot.name}</span>
+                  <span class="ballot-spot-type">{spot.type}</span>
+                </div>
+              </li>
+            {/each}
+          </ol>
+
+          {#if submitError}
+            <div class="submit-error">{submitError}</div>
+          {/if}
+
+          <button
+            class="submit-btn"
+            disabled={submitting}
+            on:click={submitBallot}
+          >
+            {submitting ? 'Submitting…' : 'Submit my rankings'}
+          </button>
+        </div>
+      {/if}
+
+      <!-- Spots list footer (always shown for reference) -->
+      {#if !isLocked && sessionSites.length > 0}
+        <div class="spots-footer">
+          {sessionSites.length} spot{sessionSites.length !== 1 ? 's' : ''} in this summit
+        </div>
+      {/if}
+    {/if}
+  </div>
+</div>
+
+<style>
+  .page {
+    min-height: 100vh;
+    padding: 2rem 1rem 4rem;
+  }
+
+  :global(.dark) .page { background: #0a0e1a; }
+
+  .container {
+    max-width: 560px;
+    margin: 0 auto;
+  }
+
+  .back-btn {
+    background: none;
+    border: none;
+    color: #6b7280;
+    cursor: pointer;
+    font-size: 0.875rem;
+    padding: 0;
+    margin-bottom: 1.5rem;
+  }
+  .back-btn:hover { color: #FE795D; }
+  :global(.dark) .back-btn { color: #9ca3af; }
+
+  .status-msg {
+    padding: 3rem;
+    text-align: center;
+    color: #9ca3af;
+    font-style: italic;
+  }
+
+  .error-block {
+    text-align: center;
+    padding: 3rem 1rem;
+  }
+
+  .error-icon { font-size: 3rem; margin-bottom: 1rem; }
+
+  .error-block p {
+    color: #6b7280;
+    margin-bottom: 1.5rem;
+  }
+
+  :global(.dark) .error-block p { color: #9ca3af; }
+
+  .create-btn-sm {
+    padding: 0.625rem 1.25rem;
+    background: #FE795D;
+    color: white;
+    border: none;
+    border-radius: 0.5rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .create-btn-sm:hover { background: #EF562F; }
+
+  /* Session header */
+  .session-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.25rem;
+  }
+
+  .session-title {
+    font-size: 1.5rem;
+    font-weight: 800;
+    color: #111827;
+    margin: 0;
+    flex: 1;
+  }
+  :global(.dark) .session-title { color: #f9fafb; }
+
+  .badge {
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    padding: 0.25rem 0.6rem;
+    border-radius: 9999px;
+    white-space: nowrap;
+  }
+
+  .badge-open {
+    background: rgba(254, 121, 93, 0.12);
+    color: #FE795D;
+  }
+
+  .badge-locked {
+    background: rgba(16, 185, 129, 0.12);
+    color: #059669;
+  }
+
+  :global(.dark) .badge-locked { color: #34d399; }
+
+  /* Creator panel */
+  .creator-panel {
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.75rem;
+    padding: 1rem 1.25rem;
+    margin-bottom: 1.5rem;
+  }
+
+  :global(.dark) .creator-panel {
+    background: #1f2937;
+    border-color: #374151;
+  }
+
+  .creator-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #FE795D;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    margin: 0 0 0.75rem;
+  }
+
+  .share-row {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .share-input {
+    flex: 1;
+    min-width: 0;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.375rem;
+    font-size: 0.8rem;
+    color: #374151;
+    background: white;
+  }
+
+  :global(.dark) .share-input {
+    background: #111827;
+    border-color: #4b5563;
+    color: #d1d5db;
+  }
+
+  .copy-btn {
+    padding: 0.5rem 0.875rem;
+    background: #FE795D;
+    color: white;
+    border: none;
+    border-radius: 0.375rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+  .copy-btn:hover { background: #EF562F; }
+
+  .creator-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .voter-count {
+    font-size: 0.8rem;
+    color: #6b7280;
+  }
+  :global(.dark) .voter-count { color: #9ca3af; }
+
+  .lock-btn {
+    padding: 0.5rem 1rem;
+    background: transparent;
+    color: #059669;
+    border: 1px solid #059669;
+    border-radius: 0.375rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+  .lock-btn:hover:not(:disabled) {
+    background: #059669;
+    color: white;
+  }
+  .lock-btn:disabled { opacity: 0.45; cursor: not-allowed; }
+
+  /* Share nudge */
+  .share-nudge {
+    font-size: 0.85rem;
+    color: #6b7280;
+    background: #f3f4f6;
+    border-radius: 0.5rem;
+    padding: 0.75rem 1rem;
+    margin-bottom: 1.25rem;
+    font-style: italic;
+  }
+  :global(.dark) .share-nudge {
+    background: #1f2937;
+    color: #9ca3af;
+  }
+
+  /* Voted banner */
+  .voted-banner {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.875rem 1rem;
+    background: rgba(16, 185, 129, 0.08);
+    border-left: 4px solid #10b981;
+    border-radius: 0 0.5rem 0.5rem 0;
+    margin-bottom: 1.5rem;
+  }
+
+  .voted-icon {
+    font-size: 1.1rem;
+    color: #10b981;
+    font-weight: 800;
+    line-height: 1.3;
+  }
+
+  .voted-title {
+    font-weight: 700;
+    color: #111827;
+    font-size: 0.9rem;
+  }
+  :global(.dark) .voted-title { color: #f9fafb; }
+
+  .voted-sub {
+    font-size: 0.8rem;
+    color: #6b7280;
+    margin-top: 0.15rem;
+  }
+  :global(.dark) .voted-sub { color: #9ca3af; }
+
+  /* Ballot */
+  .ballot-section { margin-bottom: 1.5rem; }
+
+  .ballot-heading {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: #111827;
+    margin: 0 0 0.25rem;
+  }
+  :global(.dark) .ballot-heading { color: #f9fafb; }
+
+  .ballot-sub {
+    font-size: 0.82rem;
+    color: #6b7280;
+    margin: 0 0 1rem;
+  }
+  :global(.dark) .ballot-sub { color: #9ca3af; }
+
+  .ballot-list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1rem;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    overflow: hidden;
+  }
+  :global(.dark) .ballot-list { border-color: #374151; }
+
+  .ballot-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    background: white;
+    border-bottom: 1px solid #f3f4f6;
+    transition: background 0.1s;
+  }
+  :global(.dark) .ballot-item {
+    background: #1f2937;
+    border-bottom-color: #374151;
+  }
+  .ballot-item:last-child { border-bottom: none; }
+
+  .rank-num {
+    font-size: 1rem;
+    font-weight: 800;
+    color: #FE795D;
+    width: 1.5rem;
+    text-align: center;
+    flex-shrink: 0;
+  }
+
+  .ballot-arrows {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    flex-shrink: 0;
+  }
+
+  .arrow-btn {
+    background: none;
+    border: 1px solid #e5e7eb;
+    border-radius: 3px;
+    color: #6b7280;
+    font-size: 0.6rem;
+    cursor: pointer;
+    width: 22px;
+    height: 18px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    transition: all 0.1s;
+  }
+  .arrow-btn:hover:not(:disabled) {
+    background: rgba(254, 121, 93, 0.1);
+    border-color: #FE795D;
+    color: #FE795D;
+  }
+  .arrow-btn:disabled { opacity: 0.25; cursor: not-allowed; }
+  :global(.dark) .arrow-btn {
+    border-color: #4b5563;
+    color: #9ca3af;
+  }
+
+  .ballot-spot-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    min-width: 0;
+  }
+
+  .ballot-spot-name {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #111827;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  :global(.dark) .ballot-spot-name { color: #f9fafb; }
+
+  .ballot-spot-type {
+    font-size: 0.72rem;
+    color: #9ca3af;
+  }
+
+  .submit-error {
+    padding: 0.625rem 0.875rem;
+    background: #fef2f2;
+    border: 1px solid #fca5a5;
+    border-radius: 0.375rem;
+    color: #dc2626;
+    font-size: 0.8rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .submit-btn {
+    width: 100%;
+    padding: 0.875rem;
+    background: #FE795D;
+    color: white;
+    border: none;
+    border-radius: 0.5rem;
+    font-size: 1rem;
+    font-weight: 700;
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+  .submit-btn:hover:not(:disabled) { background: #EF562F; }
+  .submit-btn:disabled { opacity: 0.45; cursor: not-allowed; }
+
+  /* Footer */
+  .spots-footer {
+    font-size: 0.75rem;
+    color: #9ca3af;
+    text-align: center;
+    margin-top: 1.5rem;
+  }
+</style>

--- a/src/routes/vote/new/+page.js
+++ b/src/routes/vote/new/+page.js
@@ -1,0 +1,1 @@
+export const prerender = false;

--- a/src/routes/vote/new/+page.svelte
+++ b/src/routes/vote/new/+page.svelte
@@ -1,0 +1,408 @@
+<script>
+  import { goto } from '$app/navigation';
+  import { browser } from '$app/environment';
+  import { processedTacoData, isLoading } from '$lib/stores.js';
+  import { supabaseBrowser } from '$lib/supabaseBrowser.js';
+
+  const MIN_SPOTS = 2;
+  const MAX_SPOTS = 6;
+
+  let title = '';
+  let searchText = '';
+  let selectedIds = new Set();
+  let creating = false;
+  let errorMsg = '';
+
+  // Filter spots by search text
+  $: filtered = $processedTacoData.filter(s => {
+    if (!searchText.trim()) return true;
+    return s.name.toLowerCase().includes(searchText.toLowerCase());
+  });
+
+  $: selectedCount = selectedIds.size;
+  $: canCreate = selectedCount >= MIN_SPOTS && selectedCount <= MAX_SPOTS && !creating;
+
+  function toggleSpot(estId) {
+    const next = new Set(selectedIds);
+    if (next.has(estId)) {
+      next.delete(estId);
+    } else if (next.size < MAX_SPOTS) {
+      next.add(estId);
+    }
+    selectedIds = next;
+  }
+
+  async function createSummit() {
+    if (!canCreate || !browser) return;
+    creating = true;
+    errorMsg = '';
+
+    // Generate a random creator token stored in localStorage
+    const creatorToken = crypto.randomUUID();
+    const sessionTitle = title.trim() || 'Taco Summit';
+    const siteIds = Array.from(selectedIds);
+
+    const { data, error } = await supabaseBrowser
+      .from('group_sessions')
+      .insert({ creator_token: creatorToken, site_ids: siteIds, title: sessionTitle })
+      .select('id')
+      .single();
+
+    if (error || !data) {
+      errorMsg = 'Could not create summit. Please try again.';
+      creating = false;
+      return;
+    }
+
+    // Persist creator token so this browser can close the session
+    localStorage.setItem(`summit_creator_${data.id}`, creatorToken);
+    goto(`/vote/${data.id}`);
+  }
+</script>
+
+<div class="page">
+  <div class="container">
+    <!-- Back -->
+    <button class="back-btn" on:click={() => goto('/')}>&larr; Back to Map</button>
+
+    <h1 class="page-title">Start a Taco Summit</h1>
+    <p class="page-subtitle">
+      Pick 2–6 spots, share the link with your crew, and let everyone rank their favourites.
+      The app tallies the votes and reveals the winner.
+    </p>
+
+    <!-- Title input -->
+    <div class="field">
+      <label for="summit-title" class="label">Summit name (optional)</label>
+      <input
+        id="summit-title"
+        type="text"
+        class="text-input"
+        placeholder="e.g. Friday Night Tacos"
+        maxlength="60"
+        bind:value={title}
+      />
+    </div>
+
+    <!-- Spot selector -->
+    <div class="field">
+      <div class="spots-header">
+        <label class="label" for="spot-search">
+          Choose spots
+          <span class="count-badge" class:maxed={selectedCount >= MAX_SPOTS}>
+            {selectedCount}/{MAX_SPOTS}
+          </span>
+        </label>
+        <input
+          id="spot-search"
+          type="search"
+          class="search-input"
+          placeholder="Search by name…"
+          bind:value={searchText}
+        />
+      </div>
+
+      {#if $isLoading}
+        <div class="status">Loading spots…</div>
+      {:else if filtered.length === 0}
+        <div class="status">No spots match "{searchText}"</div>
+      {:else}
+        <ul class="spot-list">
+          {#each filtered as site (site.est_id)}
+            {@const checked = selectedIds.has(site.est_id)}
+            {@const disabled = !checked && selectedCount >= MAX_SPOTS}
+            <li>
+              <button
+                class="spot-row"
+                class:checked
+                class:disabled
+                disabled={disabled}
+                on:click={() => toggleSpot(site.est_id)}
+                aria-pressed={checked}
+              >
+                <span class="checkbox" aria-hidden="true">{checked ? '✓' : ''}</span>
+                <span class="spot-name">{site.name}</span>
+                <span class="spot-type">{site.type}</span>
+              </button>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </div>
+
+    {#if errorMsg}
+      <div class="error">{errorMsg}</div>
+    {/if}
+
+    {#if selectedCount < MIN_SPOTS}
+      <p class="hint">Select at least {MIN_SPOTS} spots to continue.</p>
+    {/if}
+
+    <button class="create-btn" disabled={!canCreate} on:click={createSummit}>
+      {creating ? 'Creating…' : 'Create Summit & Get Link'}
+    </button>
+  </div>
+</div>
+
+<style>
+  .page {
+    min-height: 100vh;
+    padding: 2rem 1rem 4rem;
+    background: var(--bg, #f9fafb);
+  }
+
+  :global(.dark) .page {
+    background: #0a0e1a;
+  }
+
+  .container {
+    max-width: 560px;
+    margin: 0 auto;
+  }
+
+  .back-btn {
+    background: none;
+    border: none;
+    color: #6b7280;
+    cursor: pointer;
+    font-size: 0.875rem;
+    padding: 0;
+    margin-bottom: 1.5rem;
+  }
+
+  .back-btn:hover { color: #FE795D; }
+
+  :global(.dark) .back-btn { color: #9ca3af; }
+
+  .page-title {
+    font-size: 1.75rem;
+    font-weight: 800;
+    color: #111827;
+    margin: 0 0 0.5rem;
+  }
+
+  :global(.dark) .page-title { color: #f9fafb; }
+
+  .page-subtitle {
+    font-size: 0.9rem;
+    color: #6b7280;
+    margin: 0 0 2rem;
+    line-height: 1.6;
+  }
+
+  :global(.dark) .page-subtitle { color: #9ca3af; }
+
+  .field {
+    margin-bottom: 1.5rem;
+  }
+
+  .label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #374151;
+    margin-bottom: 0.5rem;
+  }
+
+  :global(.dark) .label { color: #d1d5db; }
+
+  .count-badge {
+    font-size: 0.75rem;
+    font-weight: 700;
+    padding: 0.1rem 0.45rem;
+    border-radius: 9999px;
+    background: #e5e7eb;
+    color: #374151;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .count-badge.maxed {
+    background: rgba(254, 121, 93, 0.18);
+    color: #FE795D;
+  }
+
+  :global(.dark) .count-badge {
+    background: #374151;
+    color: #d1d5db;
+  }
+
+  .text-input,
+  .search-input {
+    width: 100%;
+    padding: 0.625rem 0.875rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.5rem;
+    font-size: 0.9rem;
+    background: white;
+    color: #111827;
+    box-sizing: border-box;
+    transition: border-color 0.15s;
+  }
+
+  .text-input:focus,
+  .search-input:focus {
+    outline: none;
+    border-color: #FE795D;
+    box-shadow: 0 0 0 3px rgba(254, 121, 93, 0.15);
+  }
+
+  :global(.dark) .text-input,
+  :global(.dark) .search-input {
+    background: #1f2937;
+    border-color: #374151;
+    color: #f9fafb;
+  }
+
+  .spots-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .spots-header .label { margin-bottom: 0; }
+
+  .search-input {
+    width: auto;
+    flex: 1;
+    min-width: 160px;
+    max-width: 240px;
+    padding: 0.4rem 0.7rem;
+    font-size: 0.85rem;
+  }
+
+  .spot-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    max-height: 360px;
+    overflow-y: auto;
+  }
+
+  :global(.dark) .spot-list { border-color: #374151; }
+
+  .spot-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    width: 100%;
+    padding: 0.7rem 1rem;
+    background: white;
+    border: none;
+    border-bottom: 1px solid #f3f4f6;
+    cursor: pointer;
+    text-align: left;
+    transition: background 0.12s;
+  }
+
+  :global(.dark) .spot-row {
+    background: #1f2937;
+    border-bottom-color: #374151;
+  }
+
+  .spot-row:last-child { border-bottom: none; }
+
+  .spot-row:hover:not(.disabled) { background: #fef3f0; }
+  :global(.dark) .spot-row:hover:not(.disabled) { background: rgba(254, 121, 93, 0.08); }
+
+  .spot-row.checked { background: rgba(254, 121, 93, 0.08); }
+  :global(.dark) .spot-row.checked { background: rgba(254, 121, 93, 0.15); }
+
+  .spot-row.disabled { opacity: 0.4; cursor: not-allowed; }
+
+  .checkbox {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    border: 2px solid #d1d5db;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: 700;
+    color: white;
+    background: white;
+    flex-shrink: 0;
+    transition: all 0.12s;
+  }
+
+  .spot-row.checked .checkbox {
+    background: #FE795D;
+    border-color: #FE795D;
+  }
+
+  :global(.dark) .checkbox {
+    border-color: #4b5563;
+    background: #111827;
+  }
+
+  .spot-name {
+    flex: 1;
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: #111827;
+  }
+
+  :global(.dark) .spot-name { color: #f9fafb; }
+
+  .spot-type {
+    font-size: 0.72rem;
+    color: #9ca3af;
+    flex-shrink: 0;
+  }
+
+  .status {
+    padding: 1.5rem;
+    text-align: center;
+    color: #9ca3af;
+    font-size: 0.875rem;
+    font-style: italic;
+  }
+
+  .hint {
+    font-size: 0.8rem;
+    color: #9ca3af;
+    margin: 0 0 1rem;
+  }
+
+  .error {
+    padding: 0.75rem 1rem;
+    background: #fef2f2;
+    border: 1px solid #fca5a5;
+    border-radius: 0.5rem;
+    color: #dc2626;
+    font-size: 0.875rem;
+    margin-bottom: 1rem;
+  }
+
+  :global(.dark) .error {
+    background: rgba(220, 38, 38, 0.12);
+    border-color: rgba(220, 38, 38, 0.4);
+    color: #f87171;
+  }
+
+  .create-btn {
+    width: 100%;
+    padding: 0.875rem;
+    background: #FE795D;
+    color: white;
+    border: none;
+    border-radius: 0.5rem;
+    font-size: 1rem;
+    font-weight: 700;
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+
+  .create-btn:hover:not(:disabled) { background: #EF562F; }
+  .create-btn:disabled { opacity: 0.45; cursor: not-allowed; }
+</style>

--- a/src/routes/vote/new/+page.svelte
+++ b/src/routes/vote/new/+page.svelte
@@ -236,7 +236,7 @@
     padding: 0.625rem 0.875rem;
     border: 1px solid #d1d5db;
     border-radius: 0.5rem;
-    font-size: 0.9rem;
+    font-size: 1rem; /* 16px min prevents iOS Safari auto-zoom on focus */
     background: white;
     color: #111827;
     box-sizing: border-box;

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,5 +10,8 @@ export default defineConfig({
     host: true, // Expose to local network (same as '0.0.0.0')
     port: 5175,
     strictPort: false // Try next port if 5175 is taken
+  },
+  ssr: {
+    noExternal: ['phosphor-svelte']
   }
 });


### PR DESCRIPTION
## Summary
Implements "Taco Summit," a new group decision-making feature that allows users to create shareable voting sessions where groups can rank taco spots and see real-time results. This solves the "where should we go?" problem with a fun, collaborative voting experience.

## Key Changes

**New Pages & Components:**
- `src/routes/vote/new/+page.svelte` — Summit creation UI where users select 2–6 spots and set an optional title
- `src/routes/vote/[session_id]/+page.svelte` — Main voting & results page with ranked-choice ballot, live vote tallying, and creator controls
- `src/components/SummitResults.svelte` — Results visualization using ECharts with Borda scoring, rank distribution, and live/locked states

**Database Schema:**
- `migrations/021_create_group_sessions.sql` — Sessions table storing creator token, site IDs, title, and closed_at timestamp
- `migrations/022_create_group_votes.sql` — Votes table storing per-voter rankings with RLS policies for public read access

**UI Integration:**
- Added "🌮 Summit" navigation button to Header (desktop & mobile) linking to `/vote/new`

## Implementation Details

- **Voter Identity**: Anonymous voters identified by localStorage-persisted UUID tokens; creators identified by separate creator tokens
- **Ballot State**: Ranked list built with up/down arrow buttons; users can reorder spots before submission
- **Vote Submission**: Deletes previous votes from same voter (allows re-voting while open), inserts new ranked ballot
- **Real-time Updates**: Supabase Realtime subscriptions on `group_votes` and `group_sessions` tables for live vote counts and session state
- **Results Scoring**: Borda count (n points for 1st choice, n-1 for 2nd, etc.) with rank distribution visualization
- **Session Lifecycle**: Creator can lock session to finalize results; locked sessions show final tally instead of ballot
- **Dark Mode**: Full dark theme support across all new pages and components
- **Accessibility**: Proper ARIA labels, semantic HTML, keyboard navigation on ballot controls

## User Flow

1. User clicks "Summit" → creates new session with 2–6 spots and optional title
2. Creator gets shareable link and can copy it to invite others
3. Voters visit link, see ballot with spots in session order, rank them with arrows
4. Votes submit and appear in live results preview (Borda chart + winner callout)
5. Creator locks session when ready → results finalize and display
6. Non-creators see "waiting for creator" message after voting

https://claude.ai/code/session_01P9jriUNZwWUKLK5Zc6oLNq