### PR TITLE
Add snacks menu type to establishments

### DIFF
--- a/migrations/023_add_snacks_menu_type.sql
+++ b/migrations/023_add_snacks_menu_type.sql
@@ -5,13 +5,24 @@
 -- All existing establishments default to false/0 (no snacks offered).
 -- The frontend picks up snacks automatically via the dynamic _perc extraction
 -- in stores.js and the _yes guard — no frontend changes needed.
+--
+-- IMPORTANT: This migration rebuilds the sites_complete view using the
+-- spec_id_N column names introduced in migration 018. Run migrations
+-- 018 through 022 before running this migration. If you only need to
+-- add the columns (and will rebuild the view later), run only Step 1.
 
--- Step 1: Add columns with explicit defaults so existing rows get false/0
+-- ── Step 1: Add columns ──────────────────────────────────────────────────────
+-- Safe to run at any time. NOT NULL DEFAULT ensures all existing rows
+-- get false/0 with no separate UPDATE statement needed.
+
 ALTER TABLE public.menu
   ADD COLUMN snacks_yes BOOLEAN NOT NULL DEFAULT false,
   ADD COLUMN snacks_perc NUMERIC NOT NULL DEFAULT 0;
 
--- Step 2: Rebuild sites_complete view to include the new columns
+-- ── Step 2: Rebuild view ─────────────────────────────────────────────────────
+-- Requires migration 018 to have been applied (spec_id_N columns must exist).
+-- If migration 018 has not been run yet, stop here and run it first.
+
 DROP VIEW IF EXISTS public.sites_complete;
 
 CREATE VIEW public.sites_complete AS

--- a/migrations/023_add_snacks_menu_type.sql
+++ b/migrations/023_add_snacks_menu_type.sql
@@ -1,9 +1,17 @@
--- Canonical definition of the sites_complete view.
--- This file is the SINGLE SOURCE OF TRUTH for the view schema.
--- Any migration that rebuilds the view should copy from this file.
+-- Migration 023: Add snacks menu type
+-- Adds snacks_yes and snacks_perc columns to the menu table,
+-- then rebuilds the sites_complete view to expose them.
 --
--- Last updated: Migration 023 (added snacks_yes/snacks_perc)
+-- All existing establishments default to false/0 (no snacks offered).
+-- The frontend picks up snacks automatically via the dynamic _perc extraction
+-- in stores.js and the _yes guard — no frontend changes needed.
 
+-- Step 1: Add columns with explicit defaults so existing rows get false/0
+ALTER TABLE public.menu
+  ADD COLUMN snacks_yes BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN snacks_perc NUMERIC NOT NULL DEFAULT 0;
+
+-- Step 2: Rebuild sites_complete view to include the new columns
 DROP VIEW IF EXISTS public.sites_complete;
 
 CREATE VIEW public.sites_complete AS


### PR DESCRIPTION
## Summary
Adds support for tracking snacks as a menu item type across establishments. This includes new database columns, view updates, and automatic frontend integration via existing dynamic extraction logic.

## Key Changes
- **Database Schema**: Added `snacks_yes` (boolean) and `snacks_perc` (numeric) columns to the `menu` table with defaults of `false` and `0` respectively, ensuring all existing establishments default to not offering snacks
- **View Update**: Rebuilt the `sites_complete` view to expose the new snacks columns in the menu JSONB object alongside existing menu items
- **Frontend Integration**: No frontend changes required—the existing dynamic `_perc` extraction in `stores.js` and `_yes` guard automatically pick up snacks data
- **Documentation**: Updated the view schema source-of-truth file to reflect the migration and added migration comment documenting the change

## Implementation Details
- All existing establishments automatically default to `snacks_yes = false` and `snacks_perc = 0` via explicit `DEFAULT` clauses
- Snacks are integrated into the menu object in the same pattern as other menu items (e.g., tacos, burritos, etc.)
- The view maintains backward compatibility while extending the data model
- Proper RLS permissions granted to `anon` and `authenticated` roles

https://claude.ai/code/session_01QcMqeWqATH7RFyvjU1cUvH