### PR TITLE
Enable RLS on staging_extractions and fix sites_complete security

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,8 @@ Migrations must be run in this order:
 21. `migrations/021_create_group_sessions.sql` - Creates `group_sessions` table for Taco Summit feature (id, creator_token, site_ids, title, closed_at) with open RLS policies
 22. `migrations/022_create_group_votes.sql` - Creates `group_votes` table for ranked-choice ballots (session_id, voter_token, est_id, rank) with unique constraint and index
 23. `migrations/023_add_snacks_menu_type.sql` - Adds snacks as a menu type
+24. `migrations/024_enable_rls_staging_extractions.sql` - Enables RLS on staging_extractions table (admin data-entry helper app); authenticated users get SELECT/INSERT/UPDATE, anonymous blocked
+25. `migrations/025_fix_sites_complete_security_invoker.sql` - Fixes SECURITY DEFINER warning on sites_complete view by setting security_invoker = true (PostgreSQL 15+)
 
 ### Schema Management
 - **`schema/sites_complete_view.sql`** is the single source of truth for the `sites_complete` view definition

--- a/migrations/024_enable_rls_staging_extractions.sql
+++ b/migrations/024_enable_rls_staging_extractions.sql
@@ -1,0 +1,28 @@
+-- Migration 024: Enable RLS on staging_extractions
+-- This table is used by the admin data-entry helper app (input interface
+-- for adding new establishments to the backend).
+-- Enable RLS to resolve the Supabase security advisor warning.
+-- Policies allow authenticated users full read/write access;
+-- anonymous users are blocked entirely.
+-- The service role bypasses RLS and retains unrestricted access.
+
+ALTER TABLE public.staging_extractions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow authenticated read access"
+  ON public.staging_extractions
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+CREATE POLICY "Allow authenticated insert"
+  ON public.staging_extractions
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (true);
+
+CREATE POLICY "Allow authenticated update"
+  ON public.staging_extractions
+  FOR UPDATE
+  TO authenticated
+  USING (true)
+  WITH CHECK (true);

--- a/migrations/025_fix_sites_complete_security_invoker.sql
+++ b/migrations/025_fix_sites_complete_security_invoker.sql
@@ -1,0 +1,13 @@
+-- Migration 025: Fix SECURITY DEFINER warning on sites_complete view
+-- The Supabase security advisor flags views created with the view owner's
+-- permissions (SECURITY DEFINER behavior) rather than the querying user's.
+-- Explicitly setting security_invoker = true ensures the view executes
+-- with the caller's permissions, which is the correct and safer default.
+--
+-- This does not change observable behavior: all underlying tables already
+-- have public SELECT policies via migration 006, so anon and authenticated
+-- users can read data through the view as before.
+--
+-- Requires PostgreSQL 15+.
+
+ALTER VIEW public.sites_complete SET (security_invoker = true);

--- a/schema/sites_complete_view.sql
+++ b/schema/sites_complete_view.sql
@@ -2,11 +2,11 @@
 -- This file is the SINGLE SOURCE OF TRUTH for the view schema.
 -- Any migration that rebuilds the view should copy from this file.
 --
--- Last updated: Migration 023 (added snacks_yes/snacks_perc)
+-- Last updated: Migration 025 (added security_invoker = true)
 
 DROP VIEW IF EXISTS public.sites_complete;
 
-CREATE VIEW public.sites_complete AS
+CREATE VIEW public.sites_complete WITH (security_invoker = true) AS
 SELECT
   s.est_id,
 


### PR DESCRIPTION
## Summary
This PR addresses two Supabase security advisor warnings by enabling Row Level Security (RLS) on the `staging_extractions` table and fixing the SECURITY DEFINER behavior on the `sites_complete` view.

## Key Changes
- **Enable RLS on `staging_extractions` table** (Migration 024)
  - Adds three policies allowing authenticated users full SELECT/INSERT/UPDATE access
  - Blocks anonymous users entirely
  - Service role retains unrestricted access via RLS bypass
  - Resolves security advisor warning for this admin data-entry helper table

- **Fix `sites_complete` view security** (Migration 025)
  - Sets `security_invoker = true` on the view to execute with caller's permissions instead of view owner's
  - Replaces unsafe SECURITY DEFINER default behavior with explicit security_invoker setting
  - No observable behavior change: underlying tables already have public SELECT policies
  - Requires PostgreSQL 15+

- **Update schema documentation**
  - Updates `sites_complete_view.sql` to reflect the new security_invoker setting
  - Updates `CLAUDE.md` with migration descriptions

## Implementation Details
- Both migrations follow the existing pattern and are properly ordered (024, 025)
- RLS policies on `staging_extractions` use simple `true` conditions since all authenticated users should have equal access
- The `sites_complete` view change is a configuration-only update with no schema restructuring needed

https://claude.ai/code/session_016R3LZJicCS1NxpnZo81AhH