### PR TITLE
feat: add quesadilla as menu type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ Migrations must be run in this order:
 23. `migrations/023_add_snacks_menu_type.sql` - Adds snacks as a menu type
 24. `migrations/024_enable_rls_staging_extractions.sql` - Enables RLS on staging_extractions table (admin data-entry helper app); authenticated users get SELECT/INSERT/UPDATE, anonymous blocked
 25. `migrations/025_fix_sites_complete_security_invoker.sql` - Fixes SECURITY DEFINER warning on sites_complete view by setting security_invoker = true (PostgreSQL 15+)
+26. `migrations/026_add_quesadilla_to_view.sql` - Adds quesadilla_yes/quesadilla_perc to sites_complete view (columns already exist in menu table)
 
 ### Schema Management
 - **`schema/sites_complete_view.sql`** is the single source of truth for the `sites_complete` view definition

--- a/migrations/026_add_quesadilla_to_view.sql
+++ b/migrations/026_add_quesadilla_to_view.sql
@@ -1,8 +1,11 @@
--- Canonical definition of the sites_complete view.
--- This file is the SINGLE SOURCE OF TRUTH for the view schema.
--- Any migration that rebuilds the view should copy from this file.
+-- Migration 026: Add quesadilla menu type to sites_complete view
+-- The quesadilla_yes and quesadilla_perc columns already exist in the menu table.
+-- This migration only rebuilds the view to expose them.
 --
--- Last updated: Migration 026 (added quesadilla_yes/quesadilla_perc)
+-- The frontend picks up quesadilla automatically via the dynamic _perc extraction
+-- in stores.js and the _yes guard — no frontend changes needed.
+--
+-- IMPORTANT: Run migrations 001–025 before this one.
 
 DROP VIEW IF EXISTS public.sites_complete;
 


### PR DESCRIPTION
## Summary

- Adds `quesadilla_yes` and `quesadilla_perc` to the `sites_complete` view via migration 026
- Updates the canonical `schema/sites_complete_view.sql` to reflect the new fields
- No frontend changes required — `stores.js` dynamically picks up `_perc`/`_yes` pairs from the menu JSONB

## Test plan

- [ ] Run `migrations/026_add_quesadilla_to_view.sql` against Supabase
- [ ] Verify establishments with `quesadilla_yes = true` show quesadilla in their radar chart menu breakdown
- [ ] Verify establishments without quesadilla are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)