### PR TITLE
feat: handmade tortilla badge on site card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ node_modules
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
+# R history
+.Rhistory
+**/.Rhistory
+
 # Database backups
 restore_database.sql
 supabase_restore.sql

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-engine-strict=true
+engine-strict=false

--- a/src/components/Card.svelte
+++ b/src/components/Card.svelte
@@ -10,6 +10,7 @@
   import ContactInfo from "./ContactInfo.svelte";
   import CollapsibleSection from "./CollapsibleSection.svelte";
   import FavoriteButton from "./FavoriteButton.svelte";
+  import HandmadeBadge from "./HandmadeBadge.svelte";
   import { selectedSite, summaryStats } from "$lib/stores";
   import { isMobile } from "$lib/deviceDetection";
   import {
@@ -156,6 +157,9 @@
             <SpiceGauge spiceValue={$selectedSite.heatOverall || 0} />
             <h2 class="text-sm font-semibold text-gray-800 dark:text-gray-100 my-1">Tortilla Type</h2>
             <IconHighlight type="tortilla" data={$selectedSite.tortillaType || 'unknown'} />
+            {#if $selectedSite.handmadeTortilla}
+              <HandmadeBadge />
+            {/if}
           </div>
           <div class='salsa-container'>
             <SalsaCount
@@ -282,6 +286,9 @@
         <div class="desktop-stat-item desktop-tortilla-item">
           <h2 class="text-xs font-semibold text-gray-800 dark:text-gray-100 mb-1">Tortilla</h2>
           <IconHighlight type="tortilla" data={$selectedSite.tortillaType || 'unknown'} />
+          {#if $selectedSite.handmadeTortilla}
+            <HandmadeBadge />
+          {/if}
         </div>
         <div class="desktop-stat-item desktop-salsa-item">
           <SalsaCount

--- a/src/components/HandmadeBadge.svelte
+++ b/src/components/HandmadeBadge.svelte
@@ -1,0 +1,28 @@
+<script>
+  import { HandPalm } from 'phosphor-svelte';
+</script>
+
+<div class="handmade-badge">
+  <HandPalm size={14} color="white" weight="fill" />
+  <span>Handmade Tortillas</span>
+</div>
+
+<style>
+  .handmade-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 8px;
+    padding: 5px 12px;
+    border-radius: 16px;
+    background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+    box-shadow: 0 2px 8px rgba(245, 158, 11, 0.4);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.6px;
+    text-transform: uppercase;
+    color: white;
+    user-select: none;
+  }
+
+</style>

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -134,6 +134,7 @@ export const processedTacoData = derived(
 
           // Other details
           tortillaType: site.menu.flour_corn,
+          handmadeTortilla: site.menu.handmade_tortilla ?? false,
 
           // Specialty items — embedded in the view, no separate fetch needed
           specialties: [


### PR DESCRIPTION
## Summary
- Exposes the existing `handmade_tortilla` boolean from the `menu` table / `sites_complete` view in `processedTacoData` as `handmadeTortilla`
- Adds new `HandmadeBadge.svelte` component — amber/gold gradient pill with a Phosphor `HandPalm` icon and uppercase "Handmade Tortillas" label
- Badge renders conditionally in both the mobile and desktop Card layouts, next to the Tortilla Type indicator
- Loosens `engine-strict` in `.npmrc` from `true` → `false` to allow Node 23

## Test plan
- [ ] Click a map marker for a location with `handmade_tortilla = true` — badge appears in both mobile and desktop card views
- [ ] Click a marker without `handmade_tortilla = true` — badge does not appear
- [ ] Toggle dark mode — badge remains readable
- [ ] Run `pnpm check` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)