### PR TITLE
feat: social features — anti-review (C6) + profile foundations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ The app uses Svelte stores (src/lib/stores.js) for centralized state:
 - `tourActive` - Whether the tour overlay is showing
 - `tourStep` - Current step index (0-based)
 - `tourExpandFilters` - Whether to expand filters during the filters tour step
-- `TOUR_STEPS` - Array of 10 step definitions: `welcome`, `search`, `surprise`, `filters`, `trail`, `summit`, `map`, `theme`, `signup`, `done`
+- `TOUR_STEPS` - Array of 11 step definitions: `welcome`, `search`, `surprise`, `filters`, `trail`, `summit`, `map`, `vibe`, `theme`, `signup`, `done`
   - Each step has `id`, `target` (CSS selector or null for centered modal), `title`, `description`, optional `onEnter` action
 - Functions: `startTour()`, `endTour()`, `nextStep()`, `prevStep()`, `shouldAutoStart()`
 - Persistence: localStorage key `cartoTaco_tourCompleted`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ Migrations must be run in this order:
 24. `migrations/024_enable_rls_staging_extractions.sql` - Enables RLS on staging_extractions table (admin data-entry helper app); authenticated users get SELECT/INSERT/UPDATE, anonymous blocked
 25. `migrations/025_fix_sites_complete_security_invoker.sql` - Fixes SECURITY DEFINER warning on sites_complete view by setting security_invoker = true (PostgreSQL 15+)
 26. `migrations/026_add_quesadilla_to_view.sql` - Adds quesadilla_yes/quesadilla_perc to sites_complete view (columns already exist in menu table)
+27. `migrations/027_create_vibe_votes.sql` - Creates `vibe_votes` table for the anti-review feature (binary emoji votes across four dimensions: heat_legit, authentic, value, vibe). Public SELECT for aggregate counts; INSERT/DELETE gated on `auth.uid() = user_id`
 
 ### Schema Management
 - **`schema/sites_complete_view.sql`** is the single source of truth for the `sites_complete` view definition
@@ -104,6 +105,13 @@ The app uses Svelte stores (src/lib/stores.js) for centralized state:
 - `favoritesLoading` - Loading state
 - `favoritesCount` (derived) - Count of favorited sites
 - Functions: `loadFavorites()`, `addFavorite(estId)`, `removeFavorite(estId)`, `toggleFavorite(estId)`, `isFavorited(estId)`
+
+### Vibe Votes Store (src/lib/vibeVotesStore.js)
+- `userVibeVoteKeys` - Set of `"${estId}:${dimension}"` strings for the current user's votes
+- `vibeCountsByEst` - `Map<estId, {heat_legit, authentic, value, vibe}>` aggregate cache, populated lazily when a Card opens
+- `VIBE_DIMENSIONS` - `['heat_legit', 'authentic', 'value', 'vibe']`
+- Functions: `loadUserVibeVotes()`, `loadVibeCounts(estId, { force })`, `toggleVibeVote(estId, dimension)`, `hasVoted(estId, dimension)`
+- Optimistic UI: toggle flips the user state and bumps the count immediately, reverting on DB failure
 
 ### Trail Store (src/lib/trailStore.js)
 - `trailModeActive` - Whether trail building mode is active
@@ -238,6 +246,7 @@ Located in src/lib/dataWrangling.js:
 - `TasteProfile.svelte` - Personal taste profile visualization with archetype display, protein affinities, and scatter plot (heat vs salsa)
 - `TourOverlay.svelte` - Multi-step onboarding tour with targeted tooltips, step highlighting, and next/prev/skip navigation
 - `SummitResults.svelte` - Taco Summit results view: ECharts stacked horizontal bar showing rank distribution per spot (orange gradient), winner callout, dark-mode reactive, optional PNG card download
+- `VibeVotes.svelte` - Anti-review chip row on each Card: 🔥 Heat Legit · 🌮 Authentic · 💸 Value · 🎭 Vibe. Click toggles your vote (anonymous users redirected to login); displays aggregate counts. Accepts `compact` prop for tight desktop layouts.
 
 ### Routes
 - `src/routes/+layout.svelte` - Root layout (Header, theme initialization)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,8 @@ Migrations must be run in this order:
 25. `migrations/025_fix_sites_complete_security_invoker.sql` - Fixes SECURITY DEFINER warning on sites_complete view by setting security_invoker = true (PostgreSQL 15+)
 26. `migrations/026_add_quesadilla_to_view.sql` - Adds quesadilla_yes/quesadilla_perc to sites_complete view (columns already exist in menu table)
 27. `migrations/027_create_vibe_votes.sql` - Creates `vibe_votes` table for the anti-review feature (binary emoji votes across four dimensions: heat_legit, authentic, value, vibe). Public SELECT for aggregate counts; INSERT/DELETE gated on `auth.uid() = user_id`
+28. `migrations/028_extend_profiles.sql` - Adds `username` (UNIQUE slug, `[a-z0-9_]{3,20}`) and `bio` (≤280 chars) to `profiles`; updates the signup trigger to auto-generate a unique username from the email local-part; backfills existing rows; opens SELECT to anon/authenticated for `/u/[username]` browsing
+29. `migrations/029_create_avatars_bucket.sql` - Creates the `avatars` Storage bucket (public-read, 1 MB cap, image/* mime types) and RLS on `storage.objects` so users can only write to their own folder (`avatars/<user_id>/`)
 
 ### Schema Management
 - **`schema/sites_complete_view.sql`** is the single source of truth for the `sites_complete` view definition
@@ -219,6 +221,8 @@ Located in src/lib/dataWrangling.js:
 - `src/lib/theme.js` - Dark/light mode management
 - `src/lib/deviceDetection.js` - Responsive device type detection (mobile/tablet/desktop)
 - `src/lib/supabaseBrowser.js` - Browser-side Supabase client using `@supabase/ssr` `createBrowserClient` with cookie support; exports `supabaseBrowser` client and `getAuthenticatedUser()` helper
+- `src/lib/profiles.js` - Profiles CRUD: `getOwnProfile()`, `getProfileByUsername()`, `updateProfile()`, `uploadAvatar()`. Public reads use only safe columns (no email). Avatar uploads write to `avatars/<user_id>/avatar.{ext}` and bust browser cache via `?t=` query param.
+- `src/lib/toastStore.js` - Tiny non-blocking notification store with `toast.success/error/info()` helpers. Rendered by `<ToastHost />` mounted once in `+layout.svelte`.
 
 ## Component Organization
 
@@ -247,6 +251,7 @@ Located in src/lib/dataWrangling.js:
 - `TourOverlay.svelte` - Multi-step onboarding tour with targeted tooltips, step highlighting, and next/prev/skip navigation
 - `SummitResults.svelte` - Taco Summit results view: ECharts stacked horizontal bar showing rank distribution per spot (orange gradient), winner callout, dark-mode reactive, optional PNG card download
 - `VibeVotes.svelte` - Anti-review chip row on each Card: 🔥 Heat Legit · 🌮 Authentic · 💸 Value · 🎭 Vibe. Click toggles your vote (anonymous users redirected to login); displays aggregate counts. Accepts `compact` prop for tight desktop layouts.
+- `ToastHost.svelte` - Renders the `toasts` store as a stack of dismissable notifications, mounted once in `+layout.svelte`. Uses Phosphor `CheckCircle/WarningCircle/Info/X` icons.
 
 ### Routes
 - `src/routes/+layout.svelte` - Root layout (Header, theme initialization)
@@ -260,6 +265,7 @@ Located in src/lib/dataWrangling.js:
 - `src/routes/compare/+page.js` - Route config for comparison page
 - `src/routes/vote/new/+page.svelte` - Taco Summit creation: pick 2–6 spots, set a title, creates a `group_sessions` row and redirects to the voting page
 - `src/routes/vote/[session_id]/+page.svelte` - Taco Summit voting/results page; states: ranked-choice ballot entry, post-vote waiting with live preview, locked results with `SummitResults`; uses Supabase Realtime for live vote counts and session lock detection; anonymous via `voter_token` UUID in localStorage; creator identified by `creator_token` in localStorage
+- `src/routes/u/[username]/+page.svelte` + `+page.server.js` - Public profile page; server load looks up `profiles` by username (404 if not found); renders avatar, display name, username, bio, member-since. Recent check-ins section is a placeholder until Phase 3 ships.
 
 #### Authentication Routes (`src/routes/(auth)/`)
 - `login/+page.svelte` - Login form

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -20,6 +20,10 @@ This document outlines potential improvements to enhance CartoTaco's functionali
 14. **Onboarding Tour System** - 7-step guided tour with targeted tooltips, localStorage persistence, and restartable from help button
 15. **New Spots Badge** - Notification badge for recently added establishments with localStorage-based "seen" tracking and map fly-to on click
 16. **Bottom Sheet Mobile UX** - Mobile-optimized card display with bottom sheet pattern, swipe-to-dismiss, and iOS Safari compatibility fixes
+17. **Anti-Review Vibe Votes (C6)** - Four binary emoji chips per Card (Heat Legit, Authentic, Value, Vibe) replacing star ratings. Phosphor icons, optimistic toggle, aggregate counts public. Tour step explains the system.
+18. **Profile Foundations** - `username` (UNIQUE slug) + `bio` on `profiles`; auto-generated usernames on signup; public `/u/[username]` route with SSR 404; avatar uploads via Supabase Storage `avatars` bucket; profile editor with live username validation.
+19. **Toast Notification System** - Tiny non-blocking notification store + `ToastHost` mounted once in `+layout`. Phosphor icons for success/error/info; auto-dismiss; dismissable.
+20. **iPad Header Layout Fix** - Bumped desktop-nav breakpoint from 768px → 1100px so iPad portrait and split-view widths get the hamburger menu instead of an overflowing 8-item nav.
 
 See [QUERY_OPTIMIZATION.md](./QUERY_OPTIMIZATION.md), [SEARCH_FILTER.md](./SEARCH_FILTER.md), [MARKER_CLUSTERING.md](./MARKER_CLUSTERING.md), and [USER_SUBMISSIONS.md](./USER_SUBMISSIONS.md) for details.
 
@@ -115,24 +119,8 @@ See [QUERY_OPTIMIZATION.md](./QUERY_OPTIMIZATION.md), [SEARCH_FILTER.md](./SEARC
 
 ## 🚀 User Engagement Features
 
-### 4. Community Ratings & Quick Reviews
-**Features**:
-- 5-star rating system per establishment
-- Quick tags (e.g., "Best carnitas", "Great salsa bar", "Family friendly")
-- Optional short text reviews
-- Display average rating on map markers
-
-**Impact**: Adds social proof and user-generated content
-
-**Effort**: High (1 week)
-
-**Technical Details**:
-- Requires user authentication (already implemented)
-- Create `ratings` table: `user_id`, `est_id`, `stars`, `review_text`, `tags`
-- Create `tags` lookup table
-- Calculate average rating in database view
-- Display ratings in popup and on markers (colored star overlay)
-- Moderation tools for inappropriate content
+### 4. Community Ratings & Quick Reviews — ❌ Superseded
+**Status**: Replaced by the **Social Features Arc** (see above). The Anti-Review Vibe Votes (C6, ✅ shipped) intentionally avoids star ratings; user-generated commentary moves into Phase 3 check-in notes (≤280 chars, optional). No 5-star system planned.
 
 ---
 
@@ -157,36 +145,117 @@ See [QUERY_OPTIMIZATION.md](./QUERY_OPTIMIZATION.md), [SEARCH_FILTER.md](./SEARC
 
 ---
 
-## 🎮 Social & Gamification
+## 🤝 Social Features Arc
 
-### G1. Taco Passport + Check-Ins
-**Feature**:
-- Users "check in" at spots they've visited (requires auth)
-- Virtual passport that stamps each unique spot visited
-- Badges/achievements: "Al Pastor Pilgrim" (5 spots), "Taco Conquistador" (all spots), "Heat Seeker" (all 10-spice spots), "Carnivore" (tried all protein types)
-- Check-in count displayed on spot cards ("27 tacoheads have been here")
+A coherent multi-phase plan to turn CartoTaco from a solo discovery tool into a social-fabric app. Phases are sequenced so each one unlocks the next; ship in order.
 
-**Impact**: Major retention and engagement driver; makes CartoTaco genuinely memorable vs. just a directory
+| Phase | Status | Scope | Effort |
+|---|---|---|---|
+| 1. Anti-Review (C6) | ✅ Shipped 2026-05-04 | 4 emoji-chip votes per Card | ~2 days |
+| 2. Profile Foundations | ✅ Shipped 2026-05-04 | username, bio, avatar, public `/u/[username]` | ~2 days |
+| 3. Check-ins + Aficionado (G1+G2) | ⏳ Next up | geo-fenced check-ins with notes, tier badges, recent-on-Card | ~4–5 days |
+| 4. Meetups | ⏸ Planned | in-person events as a map layer with RSVPs | ~3–4 days |
+| 5. Follow / Feed / Reactions | ⏸ Planned | social graph + activity feed + check-in reactions | ~2–3 days |
+| 6. Challenges / Badges | ⏸ Stretch | client-derived achievements from check-in data | ~2 days |
 
-**Effort**: High (1 week)
-
-**Technical Details**:
-- New `check_ins` table: `user_id`, `est_id`, `checked_in_at`
-- Aggregate check-in counts in view or cached summary
-- Badges computed server-side or derived from check-in history
-- Passport page showing user's visited spots on a mini-map
+### Carry-over from Phase 2 (small)
+- **Header → public profile link**: surface `@username` (clickable to `/u/[username]`) in the desktop user-info area and mobile menu. Needs a tiny `profileStore` that loads the current user's username on auth. ~15 min follow-up; bundle with Phase 3.
 
 ---
 
-### G2. Personal Taco Stats Page
-**Feature**:
-- User profile page with stats: spots visited, proteins tried, favorite neighborhood, hottest spot tried
-- "Your taco journey" — timeline of check-ins
-- Comparison mode: "You vs. the average CartoTaco user"
+### Phase 3 — G1. Geo-fenced Check-ins + G2. Aficionado Tiers ⏳ Next up
+**Feature**: Users check in at the spot they're physically at, optionally leave a ≤280-char note, and earn tier badges as they accumulate verified visits. Recent check-ins appear on each Card; full timeline lives on `/u/[username]`. Replaces and supersedes the original G1/G2 entries.
 
-**Impact**: High engagement, encourages sharing
+**Impact**: The core social data substrate. Every later phase (feed, reactions, challenges) compounds on this.
 
-**Effort**: Moderate (3-4 days, builds on G1)
+**Effort**: High (~4–5 days)
+
+**Schema (migration 030)**:
+```sql
+CREATE TABLE check_ins (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  est_id INTEGER NOT NULL,
+  note TEXT CHECK (char_length(note) <= 280),
+  latitude NUMERIC(10,8) NOT NULL,
+  longitude NUMERIC(11,8) NOT NULL,
+  distance_m INTEGER NOT NULL,        -- server-computed via trigger
+  verified BOOLEAN NOT NULL DEFAULT false, -- distance_m <= 200
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+```
+
+**Geo-fence verification** — two layers:
+1. **Client**: `navigator.geolocation` + existing `calculateDistance()` in `src/lib/geocoding.js`. Live "✓ You're here" / "⚠ 1.2 km away" pill in the check-in modal. Allow submit either way.
+2. **Server**: `BEFORE INSERT` Postgres trigger looks up the site's lat/lon, recomputes distance from submitted coords, writes `distance_m`, sets `verified = (distance_m <= 200)`. Honor system, not fraud-proof; geo can be spoofed in DevTools.
+
+**Aficionado tiers** (client-derived from `verified` count only):
+- 🌮 Taco Tourist (5+)
+- 🌮🌮 Regular (15+)
+- 🌮🌮🌮 Aficionado (30+ across 15+ unique spots)
+- 👑 Conquistador (all spots checked in)
+
+**Components / files**:
+- `src/lib/checkIns.js` — CRUD + `getRecentForSite(est_id)` + `getForUser(user_id)`
+- `src/lib/checkInsStore.js` — own check-ins + site-scoped cache (60s TTL)
+- `src/components/CheckInButton.svelte` + `CheckInModal.svelte`
+- `src/components/RecentCheckIns.svelte` — slot on `Card.svelte` between description and Menu Summary
+- `src/components/AficionadoBadge.svelte` — reusable chip
+- Fill in the Phase 2 placeholder on `/u/[username]` with the timeline
+
+**Reuses**: `calculateDistance()`, `navigator.geolocation` pattern from `TrailTray.svelte:27`, favorites store template, `ToastHost` for confirmation, `CollapsibleSection` on Card.
+
+---
+
+### Phase 4 — Meetups
+**Feature**: Anyone authenticated can create an in-person taco meetup at a spot (or a freeform location), set a start/end time, and others RSVP. Appears as a distinct map pin from ~24h before start through end time, then disappears.
+
+**Impact**: First feature that brings users physically together. Map-native usage of CartoTaco's strength.
+
+**Effort**: Moderate (3–4 days)
+
+**Schema**:
+- `meetups(id, creator_id, est_id?, title, description, starts_at, ends_at, latitude, longitude, cancelled_at?, created_at)`
+- `meetup_rsvps(id, meetup_id, user_id, status ENUM('going','interested'))` with `UNIQUE(meetup_id, user_id)`
+
+**Map integration**: mirror the trail-layer pattern in `src/lib/mapping.js:462-559` — new `meetup-events` source + circle/symbol layers. Reactive store `upcomingMeetupsStore` populated at app init + Supabase Realtime on `meetups`.
+
+**Routes**:
+- `(protected)/meetups/new` — creation form with `LocationPicker` or site picker
+- `meetups/[id]` — detail + RSVP list
+
+**Moderation surface**: highest of any phase so far (free-text title + description). MVP gets a "Report" button writing to a simple `reports` table; admin review is manual.
+
+---
+
+### Phase 5 — Follow + Feed + Reactions
+**Feature**: Three small additions that compound hard on Phase 3:
+1. **Follows** — `user_follows(follower_id, followed_id)` with unique pair. Follow button on `/u/[username]`.
+2. **Activity feed** at `/feed` — UNION of check-ins and upcoming meetups from followed users, sorted DESC, paginated.
+3. **Reactions on check-ins** — `check_in_reactions(check_in_id, user_id, reaction TEXT CHECK in ('drool','fire','taco'))`. Aggregate count beside each check-in; tap to toggle. Zero prose = zero moderation.
+
+**Effort**: Moderate (2–3 days)
+
+---
+
+### Phase 6 — Challenges / Badges (Stretch)
+**Feature**: Pure client-derived achievements from existing check-in data. No DB writes; just a function that takes `checkIns + sites` and returns `{id, name, progress, completed}` records. Rendered on `/u/[username]` and own profile.
+
+Sample challenges:
+- **Protein Sweep** — try every protein (chicken/beef/pork/fish/veg) at verified check-ins
+- **Truck Stop** — 5 check-ins at food trucks
+- **Weekend Warrior** — check in every Saturday for 4 weeks
+- **Heat Seeker** — 3 check-ins at spots with heat ≥ 8
+
+**Effort**: Low (~2 days)
+
+---
+
+### Cross-cutting risks & call-outs
+- **Geolocation spoofing** — accepted, not engineered around. Aficionado tiers only count `verified=true`.
+- **Storage costs** — Supabase free tier handles MVP. 1 MB avatar cap enforced client + server.
+- **Realtime quota** — 200 concurrent connections on free tier. Lazy-subscribe (only when Card open, only for relevant `est_id`).
+- **Note moderation** — 280-char limit only. Add report button + length filter at Phase 3 launch; build admin tooling if abuse materializes.
 
 ---
 
@@ -539,34 +608,36 @@ See [QUERY_OPTIMIZATION.md](./QUERY_OPTIMIZATION.md), [SEARCH_FILTER.md](./SEARC
 15. ✅ **New spots badge** — COMPLETED
 16. ✅ **Bottom sheet mobile UX** — COMPLETED
 17. ✅ **"Surprise Me" button (D1)** — Quick win, fun UX
-18. **Taco Tuesday Tracker (S2)** — Weekly engagement, low effort
-19. **Tucson Taco Census page (V1)** — Press-worthy, no new data needed
-20. **Accessibility audit (P1)** — Important for inclusivity
-21. **SEO/Open Graph tags (P5)** — Low effort, better sharing
-22. **Analytics integration (P6)** — Data-driven decisions
-23. **Community ratings & reviews (#4)** — Add social proof
-24. **PWA support (P2)** — Install as app, offline capability
-25. **Price Tier filter (V2)** — Practical, needs data entry
-26. **E2E testing with Playwright (P4)** — Confidence for shipping
-27. **Code splitting (P3)** — Performance improvement
-28. **Taco Passport + Check-ins (G1)** — Big engagement feature
-29. **Personal Taco Stats (G2)** — Builds on G1
-30. **Comparison enhancements (P8)** — Expand existing feature
-31. **Taste profile tuning (P9)** — Better recommendations
-32. **Similar Spots (D3)** — Discovery improvement
-33. **Neighborhood Mode (D2)** — Hyper-local differentiation
-34. **Share Card generator (S1)** — Organic growth
-35. **Photo gallery (P7)** — Visual appeal
-36. **Heat map view (#5)** — Alternative visualization
-37. **Tour improvements (P10)** — Better onboarding
-38. **Owner Portal (O1)** — Long-term data sustainability
-39. **AI menu extraction (#11)** — Advanced automation
-40. **Tucson Taco Index (C1)** — Economic indicator, press-worthy
-41. **Neighborhood Origin Stories (C2)** — Hyper-local storytelling
-42. ✅ **Group Decision Mode (C3)** — Completed (2026-04-02)
-43. **Community Busyness Reports (C4)** — Real-time crowd signal
-44. **The Midnight Map (C5)** — Late-night discovery, visually striking
-45. **The Anti-Review (C6)** — Richer engagement than star ratings
+18. ✅ **Group Decision Mode (C3)** — Completed 2026-04-02
+19. ✅ **Anti-Review Vibe Votes (C6)** — Completed 2026-05-04 (Social Arc Phase 1)
+20. ✅ **Profile Foundations** — Completed 2026-05-04 (Social Arc Phase 2)
+21. **Check-ins + Aficionado Tiers (G1+G2)** — ⏳ Next up (Social Arc Phase 3)
+22. **Meetups** — Planned (Social Arc Phase 4)
+23. **Follow / Feed / Reactions** — Planned (Social Arc Phase 5)
+24. **Challenges / Badges** — Stretch (Social Arc Phase 6)
+25. **Taco Tuesday Tracker (S2)** — Weekly engagement, low effort
+26. **Tucson Taco Census page (V1)** — Press-worthy, no new data needed
+27. **Accessibility audit (P1)** — Important for inclusivity
+28. **SEO/Open Graph tags (P5)** — Low effort, better sharing
+29. **Analytics integration (P6)** — Data-driven decisions
+30. **PWA support (P2)** — Install as app, offline capability
+31. **Price Tier filter (V2)** — Practical, needs data entry
+32. **E2E testing with Playwright (P4)** — Confidence for shipping
+33. **Code splitting (P3)** — Performance improvement
+34. **Comparison enhancements (P8)** — Expand existing feature
+35. **Taste profile tuning (P9)** — Better recommendations
+36. **Similar Spots (D3)** — Discovery improvement
+37. **Neighborhood Mode (D2)** — Hyper-local differentiation
+38. **Share Card generator (S1)** — Organic growth
+39. **Photo gallery (P7)** — Visual appeal
+40. **Heat map view (#5)** — Alternative visualization
+41. **Tour improvements (P10)** — Better onboarding
+42. **Owner Portal (O1)** — Long-term data sustainability
+43. **AI menu extraction (#11)** — Advanced automation
+44. **Tucson Taco Index (C1)** — Economic indicator, press-worthy
+45. **Neighborhood Origin Stories (C2)** — Hyper-local storytelling
+46. **Community Busyness Reports (C4)** — Real-time crowd signal
+47. **The Midnight Map (C5)** — Late-night discovery, visually striking
 
 ---
 
@@ -592,4 +663,4 @@ See [QUERY_OPTIMIZATION.md](./QUERY_OPTIMIZATION.md), [SEARCH_FILTER.md](./SEARC
 
 ---
 
-**Last Updated**: 2026-04-01
+**Last Updated**: 2026-05-04 — Added Social Features Arc section (Phases 1–6); marked C6, Profile Foundations, Toast system, iPad header fix as shipped; superseded ratings/reviews item in favor of the arc.

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -506,19 +506,17 @@ See [QUERY_OPTIMIZATION.md](./QUERY_OPTIMIZATION.md), [SEARCH_FILTER.md](./SEARC
 
 ---
 
-### C6. The Anti-Review
+### C6. The Anti-Review ✅ COMPLETED (2026-05-04)
 **Feature**: Instead of 1–5 star ratings, each visit earns one vote across four emoji dimensions: 🔥 Heat Legit / 🌮 Authentic / 💸 Value / 🎭 Vibe. Aggregated counts display as a vibe fingerprint on each card.
 
 **Impact**: Faster to submit than a written review, more expressive than stars, highly visual. Encourages repeat engagement and generates richer per-spot character data.
 
-**Effort**: Moderate (2-3 days)
-
-**Technical Details**:
-- Requires auth (already implemented)
-- New `vibe_votes` table: `user_id`, `est_id`, `dimension` (heat/authentic/value/vibe), `voted_at`
-- One vote per dimension per user per spot (upsertable)
-- Aggregate counts displayed as icon + number in `Card.svelte`
-- No moderation burden (no text content)
+**Implementation**:
+- `migrations/027_create_vibe_votes.sql` — `vibe_votes(user_id, est_id, dimension, created_at)` with `UNIQUE(user_id, est_id, dimension)`. Public SELECT for aggregates; INSERT/DELETE gated on `auth.uid() = user_id`.
+- `src/lib/vibeVotes.js` — CRUD: `addVibeVote`, `removeVibeVote`, `getUserVibeVoteKeys`, `getVibeCountsForEst`.
+- `src/lib/vibeVotesStore.js` — `userVibeVoteKeys` Set, `vibeCountsByEst` Map cache, `toggleVibeVote()` with optimistic UI.
+- `src/components/VibeVotes.svelte` — chip row mounted on `Card.svelte` (mobile + desktop). Anonymous users redirect to login on click.
+- Counts load lazily per est_id when a Card opens; user's own vote keys load once on auth.
 
 ---
 

--- a/migrations/027_create_vibe_votes.sql
+++ b/migrations/027_create_vibe_votes.sql
@@ -1,0 +1,42 @@
+-- Migration 027: Create vibe_votes table for the anti-review feature.
+-- Users vote across four binary emoji dimensions per spot:
+--   heat_legit (the heat is real), authentic (tastes legit),
+--   value (worth the price), vibe (atmosphere/experience)
+-- One vote per (user, est_id, dimension); toggleable via insert/delete.
+
+CREATE TYPE vibe_dimension AS ENUM ('heat_legit', 'authentic', 'value', 'vibe');
+
+CREATE TABLE IF NOT EXISTS vibe_votes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    est_id INTEGER NOT NULL,
+    dimension vibe_dimension NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT TIMEZONE('utc', NOW()),
+
+    UNIQUE(user_id, est_id, dimension)
+);
+
+CREATE INDEX idx_vibe_votes_user_id ON vibe_votes(user_id);
+CREATE INDEX idx_vibe_votes_est_id ON vibe_votes(est_id);
+
+ALTER TABLE vibe_votes ENABLE ROW LEVEL SECURITY;
+
+-- Anyone (including anon) can read votes — counts are public on every Card.
+CREATE POLICY "Anyone can view vibe votes"
+    ON vibe_votes
+    FOR SELECT
+    USING (true);
+
+-- Authenticated users manage only their own votes.
+CREATE POLICY "Users can insert own vibe votes"
+    ON vibe_votes
+    FOR INSERT
+    WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own vibe votes"
+    ON vibe_votes
+    FOR DELETE
+    USING (auth.uid() = user_id);
+
+COMMENT ON TABLE vibe_votes IS 'Anti-review: binary emoji votes per dimension per user per spot';
+COMMENT ON COLUMN vibe_votes.dimension IS 'One of: heat_legit, authentic, value, vibe';

--- a/migrations/028_extend_profiles.sql
+++ b/migrations/028_extend_profiles.sql
@@ -1,0 +1,107 @@
+-- Migration 028: Extend profiles for public-facing identity.
+-- Adds:
+--   - username: lowercase slug (3-20 chars, alphanumeric + underscore), UNIQUE
+--   - bio: optional 280-char self-description
+-- Auto-generates a username on signup from the email local-part with collision
+-- handling. Backfills usernames for any existing rows that don't have one yet.
+-- Opens up SELECT to anon/authenticated so /u/[username] pages can render
+-- without auth. (Email is intentionally NOT queried by client code on the
+-- public surface; only display_name, username, avatar_url, bio, created_at.)
+
+-- 1) Schema: new columns. Username constraint allows 3-20 lowercase + digit +
+--    underscore, which keeps URLs readable and prevents homograph attacks.
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS username TEXT,
+  ADD COLUMN IF NOT EXISTS bio TEXT;
+
+ALTER TABLE public.profiles
+  DROP CONSTRAINT IF EXISTS profiles_username_format;
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_username_format
+    CHECK (username IS NULL OR username ~ '^[a-z0-9_]{3,20}$');
+
+ALTER TABLE public.profiles
+  DROP CONSTRAINT IF EXISTS profiles_bio_length;
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_bio_length
+    CHECK (bio IS NULL OR char_length(bio) <= 280);
+
+-- 2) Username generator: derive a slug from a base string, with a counter
+--    suffix on collision. Used by both the signup trigger and the backfill.
+CREATE OR REPLACE FUNCTION public.generate_unique_username(base_input TEXT, fallback_seed TEXT)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  base_slug TEXT;
+  candidate TEXT;
+  counter INT := 0;
+BEGIN
+  base_slug := lower(regexp_replace(coalesce(base_input, ''), '[^a-z0-9_]+', '_', 'g'));
+  base_slug := substring(base_slug from 1 for 16);
+  base_slug := trim(both '_' from base_slug);
+  IF base_slug IS NULL OR length(base_slug) < 3 THEN
+    base_slug := 'user_' || substr(replace(coalesce(fallback_seed, ''), '-', ''), 1, 8);
+  END IF;
+  candidate := base_slug;
+  WHILE EXISTS (SELECT 1 FROM public.profiles WHERE username = candidate) LOOP
+    counter := counter + 1;
+    candidate := substring(base_slug from 1 for 16) || '_' || counter::text;
+  END LOOP;
+  RETURN candidate;
+END;
+$$;
+
+-- 3) Update the new-user trigger to assign a username on signup.
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  uname TEXT;
+BEGIN
+  uname := public.generate_unique_username(split_part(new.email, '@', 1), new.id::text);
+  INSERT INTO public.profiles (id, email, display_name, username)
+  VALUES (
+    new.id,
+    new.email,
+    new.raw_user_meta_data->>'display_name',
+    uname
+  );
+  RETURN new;
+END;
+$$;
+
+-- 4) Backfill usernames for any existing rows.
+DO $$
+DECLARE
+  rec RECORD;
+BEGIN
+  FOR rec IN SELECT id, email FROM public.profiles WHERE username IS NULL LOOP
+    UPDATE public.profiles
+    SET username = public.generate_unique_username(split_part(rec.email, '@', 1), rec.id::text)
+    WHERE id = rec.id;
+  END LOOP;
+END $$;
+
+-- 5) Now that every row has a username, enforce NOT NULL and UNIQUE.
+ALTER TABLE public.profiles
+  ALTER COLUMN username SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS profiles_username_unique ON public.profiles (username);
+
+-- 6) Open up SELECT for public profile browsing. The existing own-only SELECT
+--    policy stays in place; this adds a permissive policy alongside it. Client
+--    code is responsible for not surfacing the email column on public pages.
+CREATE POLICY "Anyone can view profiles"
+  ON public.profiles
+  FOR SELECT
+  USING (true);
+
+-- (Optional cleanup: drop the redundant own-only SELECT policy. We keep it
+-- for now since multiple permissive SELECT policies are OR'd, harmless.)
+
+COMMENT ON COLUMN public.profiles.username IS 'Public URL slug; lowercase, 3-20 chars, [a-z0-9_].';
+COMMENT ON COLUMN public.profiles.bio IS 'Optional 280-char self-description shown on /u/[username].';

--- a/migrations/029_create_avatars_bucket.sql
+++ b/migrations/029_create_avatars_bucket.sql
@@ -1,0 +1,66 @@
+-- Migration 029: Create the `avatars` storage bucket and RLS policies for it.
+-- Path layout: avatars/<user_id>/<filename>
+-- The bucket is public-read so <img src=...> works without a signed URL;
+-- writes are restricted to the authenticated user matching the folder name.
+--
+-- NOTE: Supabase storage tables are owned by the `supabase_storage_admin`
+-- role. If running this migration through the SQL editor doesn't have
+-- permission to insert into `storage.buckets`, create the bucket via the
+-- Supabase dashboard (Storage → New bucket → name "avatars" → Public ON,
+-- 1 MB limit, allowed MIME types image/jpeg, image/png, image/webp) and
+-- only run the policy block below.
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'avatars',
+  'avatars',
+  true,
+  1048576, -- 1 MB
+  ARRAY['image/jpeg', 'image/png', 'image/webp']
+)
+ON CONFLICT (id) DO UPDATE
+SET public = EXCLUDED.public,
+    file_size_limit = EXCLUDED.file_size_limit,
+    allowed_mime_types = EXCLUDED.allowed_mime_types;
+
+-- Public read for avatars
+DROP POLICY IF EXISTS "Public can view avatars" ON storage.objects;
+CREATE POLICY "Public can view avatars"
+  ON storage.objects
+  FOR SELECT
+  USING (bucket_id = 'avatars');
+
+-- Authenticated users can upload only into their own folder.
+DROP POLICY IF EXISTS "Users upload own avatar" ON storage.objects;
+CREATE POLICY "Users upload own avatar"
+  ON storage.objects
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+DROP POLICY IF EXISTS "Users update own avatar" ON storage.objects;
+CREATE POLICY "Users update own avatar"
+  ON storage.objects
+  FOR UPDATE
+  TO authenticated
+  USING (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  )
+  WITH CHECK (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+DROP POLICY IF EXISTS "Users delete own avatar" ON storage.objects;
+CREATE POLICY "Users delete own avatar"
+  ON storage.objects
+  FOR DELETE
+  TO authenticated
+  USING (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );

--- a/src/components/Card.svelte
+++ b/src/components/Card.svelte
@@ -121,6 +121,7 @@
         </div>
         <div class="vibe-section">
           <h2 class="text-sm font-semibold text-gray-800 dark:text-gray-100 my-1">Vibe Check</h2>
+          <p class="vibe-subtitle">Tap any chip to vote on what this spot does well. Your vote, plus everyone else's, builds a vibe fingerprint — no stars, no essays.</p>
           <VibeVotes estId={$selectedSite.est_id} />
         </div>
         <CollapsibleSection title="Menu Summary" defaultOpen={false}>
@@ -249,6 +250,7 @@
 
       <!-- Row 2.5: Vibe votes (anti-review) -->
       <div class="desktop-vibe-row">
+        <span class="desktop-vibe-label">Vibe Check:</span>
         <VibeVotes estId={$selectedSite.est_id} compact={true} />
       </div>
 
@@ -498,8 +500,34 @@
     margin-top: 6px;
   }
 
+  .vibe-subtitle {
+    font-size: 11px;
+    line-height: 1.35;
+    color: #6b7280;
+    margin: 0 0 6px 0;
+  }
+
+  :global(.dark) .vibe-subtitle {
+    color: #9ca3af;
+  }
+
   .desktop-vibe-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
     padding: 2px 0;
+    flex-wrap: wrap;
+  }
+
+  .desktop-vibe-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: #6b7280;
+    flex-shrink: 0;
+  }
+
+  :global(.dark) .desktop-vibe-label {
+    color: #9ca3af;
   }
 
   /* ========== DESKTOP LAYOUT STYLES ========== */

--- a/src/components/Card.svelte
+++ b/src/components/Card.svelte
@@ -10,6 +10,7 @@
   import ContactInfo from "./ContactInfo.svelte";
   import CollapsibleSection from "./CollapsibleSection.svelte";
   import FavoriteButton from "./FavoriteButton.svelte";
+  import VibeVotes from "./VibeVotes.svelte";
   import { selectedSite, summaryStats } from "$lib/stores";
   import { isMobile } from "$lib/deviceDetection";
   import {
@@ -116,6 +117,10 @@
           >
             {showLongDescription ? "Show less" : "Read more"}
           </button>
+        </div>
+        <div class="vibe-section">
+          <h2 class="text-sm font-semibold text-gray-800 dark:text-gray-100 my-1">Vibe Check</h2>
+          <VibeVotes estId={$selectedSite.est_id} />
         </div>
         <CollapsibleSection title="Menu Summary" defaultOpen={false}>
           <div class="radar-chart-container">
@@ -236,6 +241,11 @@
             />
           </CollapsibleSection>
         </div>
+      </div>
+
+      <!-- Row 2.5: Vibe votes (anti-review) -->
+      <div class="desktop-vibe-row">
+        <VibeVotes estId={$selectedSite.est_id} compact={true} />
       </div>
 
       <!-- Row 3: Two radar charts side by side -->
@@ -475,6 +485,14 @@
     border-top: 1px solid lightgray;
     display: flex;
     flex-direction: column;
+  }
+
+  .vibe-section {
+    margin-top: 6px;
+  }
+
+  .desktop-vibe-row {
+    padding: 2px 0;
   }
 
   /* ========== DESKTOP LAYOUT STYLES ========== */

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -260,7 +260,10 @@
     gap: 1rem;
   }
 
-  @media (min-width: 768px) {
+  /* Show desktop nav only when there's room for all 8+ items.
+     Below this, fall back to the hamburger menu — iPad portrait (834px)
+     and split-view widths land here. */
+  @media (min-width: 1100px) {
     .desktop-nav {
       display: flex;
     }
@@ -439,7 +442,7 @@
     cursor: pointer;
   }
 
-  @media (min-width: 768px) {
+  @media (min-width: 1100px) {
     .mobile-menu-button {
       display: none;
     }
@@ -462,7 +465,7 @@
     border-top-color: rgba(255, 255, 255, 0.08);
   }
 
-  @media (min-width: 768px) {
+  @media (min-width: 1100px) {
     .mobile-menu {
       display: none;
     }
@@ -529,7 +532,7 @@
     gap: 0.25rem;
   }
 
-  @media (min-width: 768px) {
+  @media (min-width: 1100px) {
     .mobile-header-controls {
       display: none;
     }

--- a/src/components/ToastHost.svelte
+++ b/src/components/ToastHost.svelte
@@ -1,0 +1,98 @@
+<script>
+	import { fly, fade } from 'svelte/transition';
+	import { toasts, dismissToast } from '$lib/toastStore';
+	import CheckCircle from 'phosphor-svelte/lib/CheckCircle';
+	import WarningCircle from 'phosphor-svelte/lib/WarningCircle';
+	import Info from 'phosphor-svelte/lib/Info';
+	import X from 'phosphor-svelte/lib/X';
+</script>
+
+<div class="toast-host" aria-live="polite" aria-atomic="false">
+	{#each $toasts as t (t.id)}
+		<div
+			class="toast toast-{t.kind}"
+			role="status"
+			in:fly={{ y: 12, duration: 180 }}
+			out:fade={{ duration: 140 }}
+		>
+			{#if t.kind === 'success'}
+				<CheckCircle size={18} weight="fill" />
+			{:else if t.kind === 'error'}
+				<WarningCircle size={18} weight="fill" />
+			{:else}
+				<Info size={18} weight="fill" />
+			{/if}
+			<span class="message">{t.message}</span>
+			<button
+				class="close"
+				on:click={() => dismissToast(t.id)}
+				aria-label="Dismiss"
+			>
+				<X size={14} />
+			</button>
+		</div>
+	{/each}
+</div>
+
+<style>
+	.toast-host {
+		position: fixed;
+		bottom: 1rem;
+		left: 50%;
+		transform: translateX(-50%);
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		z-index: 10000;
+		pointer-events: none;
+		max-width: calc(100vw - 2rem);
+	}
+
+	.toast {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.625rem 0.875rem;
+		border-radius: 0.5rem;
+		background: white;
+		color: #111827;
+		font-size: 0.875rem;
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+		border: 1px solid #e5e7eb;
+		pointer-events: auto;
+		max-width: 420px;
+	}
+
+	:global(.dark) .toast {
+		background: #1f2937;
+		color: #f3f4f6;
+		border-color: #374151;
+		box-shadow: 0 4px 14px rgba(0, 0, 0, 0.4);
+	}
+
+	.toast-success { border-color: #10b981; color: #065f46; }
+	.toast-error   { border-color: #ef4444; color: #991b1b; }
+	.toast-info    { border-color: #FE795D; color: #9a3412; }
+
+	:global(.dark) .toast-success { color: #6ee7b7; }
+	:global(.dark) .toast-error   { color: #fca5a5; }
+	:global(.dark) .toast-info    { color: #FFB199; }
+
+	.message {
+		flex: 1;
+		line-height: 1.35;
+	}
+
+	.close {
+		background: transparent;
+		border: none;
+		color: inherit;
+		cursor: pointer;
+		opacity: 0.6;
+		display: flex;
+		align-items: center;
+		padding: 2px;
+	}
+
+	.close:hover { opacity: 1; }
+</style>

--- a/src/components/VibeVotes.svelte
+++ b/src/components/VibeVotes.svelte
@@ -1,23 +1,25 @@
 <script>
-	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
+	import Flame from 'phosphor-svelte/lib/Flame';
+	import SealCheck from 'phosphor-svelte/lib/SealCheck';
+	import HandCoins from 'phosphor-svelte/lib/HandCoins';
+	import Sparkle from 'phosphor-svelte/lib/Sparkle';
 	import { isAuthenticated } from '$lib/authStore';
 	import {
 		userVibeVoteKeys,
 		vibeCountsByEst,
 		loadVibeCounts,
-		toggleVibeVote,
-		VIBE_DIMENSIONS
+		toggleVibeVote
 	} from '$lib/vibeVotesStore';
 
 	export let estId;
 	export let compact = false;
 
 	const DIMENSIONS = [
-		{ key: 'heat_legit', emoji: '🔥', label: 'Heat Legit' },
-		{ key: 'authentic',  emoji: '🌮', label: 'Authentic' },
-		{ key: 'value',      emoji: '💸', label: 'Value' },
-		{ key: 'vibe',       emoji: '🎭', label: 'Vibe' }
+		{ key: 'heat_legit', icon: Flame,     label: 'Heat Legit', tooltip: 'The spice level is for real' },
+		{ key: 'authentic',  icon: SealCheck, label: 'Authentic',  tooltip: 'Tastes traditional / legit' },
+		{ key: 'value',      icon: HandCoins, label: 'Value',      tooltip: 'Worth what you pay' },
+		{ key: 'vibe',       icon: Sparkle,   label: 'Vibe',       tooltip: 'Great atmosphere & feel' }
 	];
 
 	let toggling = new Set();
@@ -44,8 +46,8 @@
 	}
 </script>
 
-<div class="vibe-votes" class:compact>
-	{#each DIMENSIONS as { key, emoji, label } (key)}
+<div class="vibe-votes" class:compact data-tour="vibe">
+	{#each DIMENSIONS as { key, icon: Icon, label, tooltip } (key)}
 		{@const active = isActive(key)}
 		{@const count = counts[key] || 0}
 		<button
@@ -55,12 +57,12 @@
 			disabled={toggling.has(key)}
 			on:click={() => handleClick(key)}
 			title={$isAuthenticated
-				? (active ? `Remove your ${label} vote` : `Vote ${label}`)
-				: `Sign in to vote ${label}`}
-			aria-label={`${label}: ${count} vote${count === 1 ? '' : 's'}`}
+				? `${label} — ${tooltip}${active ? ' (tap to remove your vote)' : ''}`
+				: `${label} — ${tooltip} (sign in to vote)`}
+			aria-label={`${label}: ${tooltip}. ${count} vote${count === 1 ? '' : 's'}.${active ? ' You voted.' : ''}`}
 			aria-pressed={active}
 		>
-			<span class="emoji" aria-hidden="true">{emoji}</span>
+			<Icon size={compact ? 14 : 16} weight={active ? 'fill' : 'regular'} class="vibe-icon" />
 			<span class="label">{label}</span>
 			<span class="count">{count}</span>
 		</button>
@@ -92,9 +94,9 @@
 		user-select: none;
 	}
 
-	.vibe-chip .emoji {
-		font-size: 14px;
-		line-height: 1;
+	.vibe-chip :global(.vibe-icon) {
+		flex-shrink: 0;
+		color: currentColor;
 	}
 
 	.vibe-chip .count {
@@ -147,7 +149,7 @@
 		color: #FE795D;
 	}
 
-	/* Compact: hide label text on small popups, keep emoji + count */
+	/* Compact: hide label text on tight desktop strips, keep icon + count */
 	.vibe-votes.compact .vibe-chip {
 		padding: 3px 7px;
 		font-size: 11px;
@@ -157,12 +159,13 @@
 		display: none;
 	}
 
+	/* Mobile: keep labels visible — they're how users learn what each chip means.
+	   Tighten padding so all four still fit comfortably. */
 	@media (max-width: 480px) {
-		.vibe-chip .label {
-			display: none;
-		}
 		.vibe-chip {
-			padding: 3px 8px;
+			padding: 4px 8px;
+			font-size: 11px;
+			gap: 4px;
 		}
 	}
 </style>

--- a/src/components/VibeVotes.svelte
+++ b/src/components/VibeVotes.svelte
@@ -1,0 +1,168 @@
+<script>
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { isAuthenticated } from '$lib/authStore';
+	import {
+		userVibeVoteKeys,
+		vibeCountsByEst,
+		loadVibeCounts,
+		toggleVibeVote,
+		VIBE_DIMENSIONS
+	} from '$lib/vibeVotesStore';
+
+	export let estId;
+	export let compact = false;
+
+	const DIMENSIONS = [
+		{ key: 'heat_legit', emoji: '🔥', label: 'Heat Legit' },
+		{ key: 'authentic',  emoji: '🌮', label: 'Authentic' },
+		{ key: 'value',      emoji: '💸', label: 'Value' },
+		{ key: 'vibe',       emoji: '🎭', label: 'Vibe' }
+	];
+
+	let toggling = new Set();
+
+	$: if (estId != null) loadVibeCounts(estId);
+	$: counts = $vibeCountsByEst.get(estId) || { heat_legit: 0, authentic: 0, value: 0, vibe: 0 };
+
+	function isActive(dim) {
+		return $userVibeVoteKeys.has(`${estId}:${dim}`);
+	}
+
+	async function handleClick(dim) {
+		if (!$isAuthenticated) {
+			goto('/login?redirect=/');
+			return;
+		}
+		if (toggling.has(dim)) return;
+		toggling = new Set(toggling).add(dim);
+		try {
+			await toggleVibeVote(estId, dim);
+		} finally {
+			toggling = new Set([...toggling].filter(d => d !== dim));
+		}
+	}
+</script>
+
+<div class="vibe-votes" class:compact>
+	{#each DIMENSIONS as { key, emoji, label } (key)}
+		{@const active = isActive(key)}
+		{@const count = counts[key] || 0}
+		<button
+			type="button"
+			class="vibe-chip"
+			class:active
+			disabled={toggling.has(key)}
+			on:click={() => handleClick(key)}
+			title={$isAuthenticated
+				? (active ? `Remove your ${label} vote` : `Vote ${label}`)
+				: `Sign in to vote ${label}`}
+			aria-label={`${label}: ${count} vote${count === 1 ? '' : 's'}`}
+			aria-pressed={active}
+		>
+			<span class="emoji" aria-hidden="true">{emoji}</span>
+			<span class="label">{label}</span>
+			<span class="count">{count}</span>
+		</button>
+	{/each}
+</div>
+
+<style>
+	.vibe-votes {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 6px;
+		padding: 4px 0;
+	}
+
+	.vibe-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 5px;
+		padding: 4px 9px;
+		border: 1px solid #e5e7eb;
+		border-radius: 999px;
+		background: #f9fafb;
+		color: #374151;
+		font-size: 12px;
+		font-weight: 500;
+		cursor: pointer;
+		transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+		-webkit-tap-highlight-color: transparent;
+		user-select: none;
+	}
+
+	.vibe-chip .emoji {
+		font-size: 14px;
+		line-height: 1;
+	}
+
+	.vibe-chip .count {
+		font-variant-numeric: tabular-nums;
+		font-weight: 600;
+		color: #6b7280;
+		min-width: 14px;
+		text-align: right;
+	}
+
+	.vibe-chip.active {
+		background: rgba(254, 121, 93, 0.12);
+		color: #FE795D;
+		border-color: #FE795D;
+	}
+
+	.vibe-chip.active .count {
+		color: #FE795D;
+	}
+
+	@media (hover: hover) {
+		.vibe-chip:hover:not(:disabled):not(.active) {
+			border-color: #FE795D;
+			color: #FE795D;
+		}
+	}
+
+	.vibe-chip:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	:global(.dark) .vibe-chip {
+		background: #374151;
+		border-color: #4b5563;
+		color: #d1d5db;
+	}
+
+	:global(.dark) .vibe-chip .count {
+		color: #9ca3af;
+	}
+
+	:global(.dark) .vibe-chip.active {
+		background: rgba(254, 121, 93, 0.18);
+		color: #FE795D;
+		border-color: #FE795D;
+	}
+
+	:global(.dark) .vibe-chip.active .count {
+		color: #FE795D;
+	}
+
+	/* Compact: hide label text on small popups, keep emoji + count */
+	.vibe-votes.compact .vibe-chip {
+		padding: 3px 7px;
+		font-size: 11px;
+	}
+
+	.vibe-votes.compact .label {
+		display: none;
+	}
+
+	@media (max-width: 480px) {
+		.vibe-chip .label {
+			display: none;
+		}
+		.vibe-chip {
+			padding: 3px 8px;
+		}
+	}
+</style>

--- a/src/lib/profiles.js
+++ b/src/lib/profiles.js
@@ -1,0 +1,150 @@
+/**
+ * Profiles — read/update profile rows and upload avatars.
+ *
+ * Public reads use only safe columns (id, username, display_name, avatar_url,
+ * bio, created_at). Email is never selected on public surfaces.
+ */
+
+import { supabaseBrowser, getAuthenticatedUser } from './supabaseBrowser';
+
+const PUBLIC_COLUMNS = 'id, username, display_name, avatar_url, bio, created_at';
+
+export const USERNAME_REGEX = /^[a-z0-9_]{3,20}$/;
+export const BIO_MAX = 280;
+export const DISPLAY_NAME_MAX = 50;
+
+/**
+ * Validate a candidate username. Returns null if valid, otherwise an error message.
+ */
+export function validateUsername(value) {
+	if (!value) return 'Username is required';
+	if (value.length < 3) return 'Must be at least 3 characters';
+	if (value.length > 20) return 'Must be 20 characters or fewer';
+	if (!USERNAME_REGEX.test(value)) return 'Use lowercase letters, numbers, and underscores only';
+	return null;
+}
+
+/**
+ * Fetch the current authenticated user's profile (full row, including email).
+ * @returns {Promise<{success: boolean, data?: object, error?: string}>}
+ */
+export async function getOwnProfile() {
+	try {
+		const { user, error: authError } = await getAuthenticatedUser();
+		if (authError) return { success: false, error: authError };
+
+		const { data, error } = await supabaseBrowser
+			.from('profiles')
+			.select('id, email, username, display_name, avatar_url, bio, created_at, updated_at')
+			.eq('id', user.id)
+			.maybeSingle();
+
+		if (error) return { success: false, error: error.message };
+		return { success: true, data };
+	} catch (error) {
+		return { success: false, error: error.message };
+	}
+}
+
+/**
+ * Look up a public profile by username (case-insensitive).
+ * @param {string} username
+ * @returns {Promise<{success: boolean, data?: object, error?: string}>}
+ */
+export async function getProfileByUsername(username) {
+	if (!username) return { success: false, error: 'Username required' };
+	try {
+		const { data, error } = await supabaseBrowser
+			.from('profiles')
+			.select(PUBLIC_COLUMNS)
+			.eq('username', username.toLowerCase())
+			.maybeSingle();
+
+		if (error) return { success: false, error: error.message };
+		if (!data) return { success: false, error: 'not_found' };
+		return { success: true, data };
+	} catch (error) {
+		return { success: false, error: error.message };
+	}
+}
+
+/**
+ * Patch the current user's profile. Pass only fields you want to change.
+ * @param {{ display_name?: string|null, username?: string|null, bio?: string|null, avatar_url?: string|null }} updates
+ */
+export async function updateProfile(updates) {
+	try {
+		const { user, error: authError } = await getAuthenticatedUser();
+		if (authError) return { success: false, error: authError };
+
+		const payload = {};
+		if ('display_name' in updates) payload.display_name = normalizeText(updates.display_name);
+		if ('username' in updates) payload.username = updates.username?.toLowerCase().trim() || null;
+		if ('bio' in updates) payload.bio = normalizeText(updates.bio);
+		if ('avatar_url' in updates) payload.avatar_url = updates.avatar_url || null;
+
+		const { data, error } = await supabaseBrowser
+			.from('profiles')
+			.update(payload)
+			.eq('id', user.id)
+			.select('id, email, username, display_name, avatar_url, bio, created_at, updated_at')
+			.single();
+
+		if (error) {
+			// Unique constraint on username
+			if (error.code === '23505') return { success: false, error: 'That username is taken' };
+			// Check constraint (regex/length)
+			if (error.code === '23514') return { success: false, error: 'Invalid username or bio format' };
+			return { success: false, error: error.message };
+		}
+		return { success: true, data };
+	} catch (error) {
+		return { success: false, error: error.message };
+	}
+}
+
+/**
+ * Upload an avatar image to storage and return its public URL.
+ * Replaces any existing file at the user's path.
+ * @param {File} file
+ * @returns {Promise<{success: boolean, url?: string, error?: string}>}
+ */
+export async function uploadAvatar(file) {
+	if (!file) return { success: false, error: 'No file selected' };
+	if (file.size > 1_048_576) return { success: false, error: 'Image must be under 1 MB' };
+	if (!['image/jpeg', 'image/png', 'image/webp'].includes(file.type)) {
+		return { success: false, error: 'Use a JPEG, PNG, or WebP image' };
+	}
+
+	try {
+		const { user, error: authError } = await getAuthenticatedUser();
+		if (authError) return { success: false, error: authError };
+
+		const ext = file.type === 'image/png' ? 'png' : file.type === 'image/webp' ? 'webp' : 'jpg';
+		const path = `${user.id}/avatar.${ext}`;
+
+		const { error: uploadError } = await supabaseBrowser
+			.storage
+			.from('avatars')
+			.upload(path, file, { upsert: true, contentType: file.type, cacheControl: '3600' });
+
+		if (uploadError) return { success: false, error: uploadError.message };
+
+		const { data: pub } = supabaseBrowser.storage.from('avatars').getPublicUrl(path);
+		// Bust caches when the file at the same path is replaced.
+		const url = `${pub.publicUrl}?t=${Date.now()}`;
+
+		const updateResult = await updateProfile({ avatar_url: url });
+		if (!updateResult.success) return { success: false, error: updateResult.error };
+
+		return { success: true, url };
+	} catch (error) {
+		return { success: false, error: error.message };
+	}
+}
+
+function normalizeText(value) {
+	if (value == null) return null;
+	const trimmed = String(value).trim();
+	return trimmed.length === 0 ? null : trimmed;
+}

--- a/src/lib/toastStore.js
+++ b/src/lib/toastStore.js
@@ -1,0 +1,34 @@
+/**
+ * Toast notifications — small, non-blocking confirmations and errors.
+ * Mounted once via <ToastHost /> in +layout.svelte.
+ */
+
+import { writable } from 'svelte/store';
+
+export const toasts = writable([]);
+
+let nextId = 1;
+
+/**
+ * Push a toast.
+ * @param {string} message
+ * @param {{ kind?: 'success'|'error'|'info', duration?: number }} [opts]
+ */
+export function pushToast(message, { kind = 'info', duration = 3500 } = {}) {
+	const id = nextId++;
+	toasts.update(list => [...list, { id, message, kind }]);
+	if (duration > 0) {
+		setTimeout(() => dismissToast(id), duration);
+	}
+	return id;
+}
+
+export function dismissToast(id) {
+	toasts.update(list => list.filter(t => t.id !== id));
+}
+
+export const toast = {
+	success: (msg, opts) => pushToast(msg, { ...opts, kind: 'success' }),
+	error: (msg, opts) => pushToast(msg, { ...opts, kind: 'error' }),
+	info: (msg, opts) => pushToast(msg, { ...opts, kind: 'info' })
+};

--- a/src/lib/tourStore.js
+++ b/src/lib/tourStore.js
@@ -53,6 +53,12 @@ export const TOUR_STEPS = [
 		description: 'Click clusters to zoom in, click markers to see details. Drag and zoom to explore all of Tucson.'
 	},
 	{
+		id: 'vibe',
+		target: null,
+		title: 'Vibe Check, not Star Reviews',
+		description: "Tap any spot to open its card and weigh in: 🔥 Heat Legit · ✓ Authentic · 💰 Value · ✨ Vibe. One tap per chip — no essays, no five-star math. Your votes plus everyone else's build a quick fingerprint of what each spot actually nails."
+	},
+	{
 		id: 'theme',
 		target: '[data-tour="theme"]',
 		title: 'Switch Themes',

--- a/src/lib/vibeVotes.js
+++ b/src/lib/vibeVotes.js
@@ -1,0 +1,117 @@
+/**
+ * Vibe votes — anti-review CRUD operations.
+ * Users toggle binary emoji votes across four dimensions per spot.
+ */
+
+import { supabaseBrowser, getAuthenticatedUser } from './supabaseBrowser';
+
+export const VIBE_DIMENSIONS = ['heat_legit', 'authentic', 'value', 'vibe'];
+
+/**
+ * Add a vibe vote for the current user.
+ * @param {number} estId
+ * @param {string} dimension - one of VIBE_DIMENSIONS
+ * @returns {Promise<{success: boolean, error?: string}>}
+ */
+export async function addVibeVote(estId, dimension) {
+	try {
+		const { user, error: authError } = await getAuthenticatedUser();
+		if (authError) return { success: false, error: authError };
+
+		const { error } = await supabaseBrowser
+			.from('vibe_votes')
+			.insert({ user_id: user.id, est_id: estId, dimension });
+
+		if (error) {
+			if (error.code === '23505') return { success: true }; // already voted
+			console.error('Error adding vibe vote:', error);
+			return { success: false, error: error.message };
+		}
+		return { success: true };
+	} catch (error) {
+		console.error('Exception adding vibe vote:', error);
+		return { success: false, error: error.message };
+	}
+}
+
+/**
+ * Remove a vibe vote for the current user.
+ * @param {number} estId
+ * @param {string} dimension
+ * @returns {Promise<{success: boolean, error?: string}>}
+ */
+export async function removeVibeVote(estId, dimension) {
+	try {
+		const { user, error: authError } = await getAuthenticatedUser();
+		if (authError) return { success: false, error: authError };
+
+		const { error } = await supabaseBrowser
+			.from('vibe_votes')
+			.delete()
+			.eq('user_id', user.id)
+			.eq('est_id', estId)
+			.eq('dimension', dimension);
+
+		if (error) {
+			console.error('Error removing vibe vote:', error);
+			return { success: false, error: error.message };
+		}
+		return { success: true };
+	} catch (error) {
+		console.error('Exception removing vibe vote:', error);
+		return { success: false, error: error.message };
+	}
+}
+
+/**
+ * Get all of the current user's vibe votes as a Set of "estId:dimension" keys.
+ * @returns {Promise<Set<string>>}
+ */
+export async function getUserVibeVoteKeys() {
+	try {
+		const { user } = await getAuthenticatedUser();
+		if (!user) return new Set();
+
+		const { data, error } = await supabaseBrowser
+			.from('vibe_votes')
+			.select('est_id, dimension')
+			.eq('user_id', user.id);
+
+		if (error) {
+			console.error('Error fetching user vibe votes:', error);
+			return new Set();
+		}
+		return new Set((data || []).map(v => `${v.est_id}:${v.dimension}`));
+	} catch (error) {
+		console.error('Exception fetching user vibe votes:', error);
+		return new Set();
+	}
+}
+
+/**
+ * Get aggregate vote counts for a single establishment.
+ * @param {number} estId
+ * @returns {Promise<{heat_legit: number, authentic: number, value: number, vibe: number}>}
+ */
+export async function getVibeCountsForEst(estId) {
+	const empty = { heat_legit: 0, authentic: 0, value: 0, vibe: 0 };
+	try {
+		const { data, error } = await supabaseBrowser
+			.from('vibe_votes')
+			.select('dimension')
+			.eq('est_id', estId);
+
+		if (error) {
+			console.error('Error fetching vibe counts:', error);
+			return empty;
+		}
+		const counts = { ...empty };
+		for (const row of data || []) {
+			if (row.dimension in counts) counts[row.dimension] += 1;
+		}
+		return counts;
+	} catch (error) {
+		console.error('Exception fetching vibe counts:', error);
+		return empty;
+	}
+}

--- a/src/lib/vibeVotesStore.js
+++ b/src/lib/vibeVotesStore.js
@@ -1,0 +1,105 @@
+/**
+ * Vibe votes store — reactive state for the anti-review feature.
+ * Holds the current user's vote keys and a per-est_id cache of aggregate counts.
+ */
+
+import { writable, get } from 'svelte/store';
+import { isAuthenticated } from './authStore';
+import {
+	addVibeVote as addVote,
+	removeVibeVote as removeVote,
+	getUserVibeVoteKeys,
+	getVibeCountsForEst,
+	VIBE_DIMENSIONS
+} from './vibeVotes';
+
+export { VIBE_DIMENSIONS };
+
+const emptyCounts = () => ({ heat_legit: 0, authentic: 0, value: 0, vibe: 0 });
+
+// "estId:dimension" keys for the current user
+export const userVibeVoteKeys = writable(new Set());
+
+// Map<estId, {heat_legit, authentic, value, vibe}>
+export const vibeCountsByEst = writable(new Map());
+
+export async function loadUserVibeVotes() {
+	if (!get(isAuthenticated)) {
+		userVibeVoteKeys.set(new Set());
+		return;
+	}
+	try {
+		const keys = await getUserVibeVoteKeys();
+		userVibeVoteKeys.set(keys);
+	} catch (error) {
+		console.error('Error loading user vibe votes:', error);
+	}
+}
+
+/**
+ * Load aggregate counts for a single establishment into the cache.
+ * @param {number} estId
+ * @param {{ force?: boolean }} [opts]
+ */
+export async function loadVibeCounts(estId, { force = false } = {}) {
+	if (estId == null) return;
+	if (!force) {
+		const cache = get(vibeCountsByEst);
+		if (cache.has(estId)) return;
+	}
+	const counts = await getVibeCountsForEst(estId);
+	vibeCountsByEst.update(map => {
+		const next = new Map(map);
+		next.set(estId, counts);
+		return next;
+	});
+}
+
+function bumpCount(estId, dimension, delta) {
+	vibeCountsByEst.update(map => {
+		const next = new Map(map);
+		const current = next.get(estId) || emptyCounts();
+		next.set(estId, { ...current, [dimension]: Math.max(0, (current[dimension] || 0) + delta) });
+		return next;
+	});
+}
+
+/**
+ * Toggle a vote, updating both the user's keys and the local count cache.
+ * @param {number} estId
+ * @param {string} dimension
+ * @returns {Promise<boolean>} true if now voted, false if removed
+ */
+export async function toggleVibeVote(estId, dimension) {
+	const key = `${estId}:${dimension}`;
+	const keys = get(userVibeVoteKeys);
+	const wasVoted = keys.has(key);
+
+	// Optimistic UI: flip the user state and bump the count immediately.
+	userVibeVoteKeys.update(s => {
+		const next = new Set(s);
+		if (wasVoted) next.delete(key);
+		else next.add(key);
+		return next;
+	});
+	bumpCount(estId, dimension, wasVoted ? -1 : 1);
+
+	const result = wasVoted ? await removeVote(estId, dimension) : await addVote(estId, dimension);
+
+	if (!result.success) {
+		// Revert on failure.
+		userVibeVoteKeys.update(s => {
+			const next = new Set(s);
+			if (wasVoted) next.add(key);
+			else next.delete(key);
+			return next;
+		});
+		bumpCount(estId, dimension, wasVoted ? 1 : -1);
+		return wasVoted;
+	}
+	return !wasVoted;
+}
+
+export function hasVoted(estId, dimension) {
+	return get(userVibeVoteKeys).has(`${estId}:${dimension}`);
+}

--- a/src/routes/(protected)/profile/+page.svelte
+++ b/src/routes/(protected)/profile/+page.svelte
@@ -4,7 +4,11 @@
   import { goto } from '$app/navigation';
   import { browser } from '$app/environment';
   import { UserCircleOutline, EnvelopeOutline, CalendarMonthOutline, HeartSolid } from 'flowbite-svelte-icons';
+  import UploadSimple from 'phosphor-svelte/lib/UploadSimple';
+  import LinkSimple from 'phosphor-svelte/lib/LinkSimple';
   import { favoritesCount, loadFavorites } from '$lib/favoritesStore';
+  import { getOwnProfile, updateProfile, uploadAvatar, validateUsername, BIO_MAX, DISPLAY_NAME_MAX } from '$lib/profiles';
+  import { toast } from '$lib/toastStore';
   import TasteProfile from '../../../components/TasteProfile.svelte';
 
   export let data;
@@ -16,10 +20,92 @@
     day: 'numeric'
   });
 
-  // Load favorites count
-  onMount(() => {
+  let profile = null;
+  let displayName = '';
+  let username = '';
+  let bio = '';
+  let avatarUrl = '';
+  let usernameError = '';
+  let savingProfile = false;
+  let uploadingAvatar = false;
+  let fileInput;
+
+  $: bioRemaining = BIO_MAX - (bio?.length || 0);
+
+  onMount(async () => {
     loadFavorites();
+    const result = await getOwnProfile();
+    if (result.success && result.data) {
+      profile = result.data;
+      displayName = result.data.display_name || '';
+      username = result.data.username || '';
+      bio = result.data.bio || '';
+      avatarUrl = result.data.avatar_url || '';
+    } else if (result.error) {
+      toast.error(`Couldn't load your profile: ${result.error}`);
+    }
   });
+
+  function handleUsernameInput(e) {
+    username = e.target.value.toLowerCase();
+    usernameError = username ? (validateUsername(username) || '') : '';
+  }
+
+  async function saveProfile() {
+    const usernameMsg = validateUsername(username);
+    if (usernameMsg) {
+      usernameError = usernameMsg;
+      return;
+    }
+    if (bio.length > BIO_MAX) {
+      toast.error(`Bio must be ${BIO_MAX} characters or fewer`);
+      return;
+    }
+
+    savingProfile = true;
+    const result = await updateProfile({
+      display_name: displayName,
+      username,
+      bio
+    });
+    savingProfile = false;
+
+    if (result.success) {
+      profile = result.data;
+      toast.success('Profile saved');
+    } else {
+      toast.error(result.error || 'Could not save profile');
+      if (result.error?.toLowerCase().includes('username')) {
+        usernameError = result.error;
+      }
+    }
+  }
+
+  async function handleAvatarChange(e) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    uploadingAvatar = true;
+    const result = await uploadAvatar(file);
+    uploadingAvatar = false;
+    if (result.success) {
+      avatarUrl = result.url;
+      toast.success('Avatar updated');
+    } else {
+      toast.error(result.error || 'Could not upload avatar');
+    }
+    if (fileInput) fileInput.value = '';
+  }
+
+  async function copyPublicLink() {
+    if (!username || !browser) return;
+    const url = `${window.location.origin}/u/${username}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      toast.success('Profile link copied');
+    } catch {
+      toast.info(url);
+    }
+  }
 
   async function handleSignOut() {
     await signOut();
@@ -33,24 +119,114 @@
 
 <div class="profile-container">
   <div class="profile-content">
-    <!-- Header -->
     <div class="profile-header">
-      {#if browser}
-        <UserCircleOutline class="profile-icon" size="xl" />
-      {/if}
+      <div class="avatar-wrapper">
+        {#if avatarUrl}
+          <img src={avatarUrl} alt="Avatar" class="avatar-image" />
+        {:else if browser}
+          <UserCircleOutline class="profile-icon" size="xl" />
+        {/if}
+        <button
+          class="avatar-edit-button"
+          on:click={() => fileInput?.click()}
+          disabled={uploadingAvatar}
+          title="Change avatar"
+          aria-label="Change avatar"
+        >
+          {#if browser}
+            <UploadSimple size={14} weight="bold" />
+          {/if}
+        </button>
+        <input
+          bind:this={fileInput}
+          type="file"
+          accept="image/jpeg,image/png,image/webp"
+          on:change={handleAvatarChange}
+          class="hidden-file-input"
+        />
+      </div>
       <h1 class="profile-title">Your Profile</h1>
+      {#if username}
+        <button class="public-link" on:click={copyPublicLink} title="Copy public profile link">
+          {#if browser}<LinkSimple size={14} />{/if}
+          <span>cartotaco.app/u/{username}</span>
+        </button>
+      {/if}
     </div>
 
-    <!-- User Info Card -->
     <div class="info-card">
+      <div class="info-section">
+        <h2 class="section-title">Public Identity</h2>
+        <p class="section-help">This is what shows on your public profile and on check-ins. Email stays private.</p>
+
+        <label class="field">
+          <span class="field-label">Display name</span>
+          <input
+            type="text"
+            class="field-input"
+            bind:value={displayName}
+            maxlength={DISPLAY_NAME_MAX}
+            placeholder="What should we call you?"
+          />
+        </label>
+
+        <label class="field">
+          <span class="field-label">
+            Username
+            <span class="field-hint">3–20 characters · lowercase, numbers, underscores</span>
+          </span>
+          <div class="username-input-wrapper">
+            <span class="username-prefix">/u/</span>
+            <input
+              type="text"
+              class="field-input"
+              class:invalid={usernameError}
+              value={username}
+              on:input={handleUsernameInput}
+              maxlength={20}
+              autocomplete="off"
+              spellcheck="false"
+            />
+          </div>
+          {#if usernameError}
+            <span class="field-error">{usernameError}</span>
+          {/if}
+        </label>
+
+        <label class="field">
+          <span class="field-label">
+            Bio
+            <span class="field-hint">{bioRemaining} characters left</span>
+          </span>
+          <textarea
+            class="field-input"
+            class:invalid={bio.length > BIO_MAX}
+            bind:value={bio}
+            maxlength={BIO_MAX}
+            rows="3"
+            placeholder="Favorite protein? Spice tolerance? Tell folks who's behind the votes."
+          ></textarea>
+        </label>
+
+        <div class="form-actions">
+          <button
+            class="primary-button"
+            on:click={saveProfile}
+            disabled={savingProfile || !!usernameError}
+          >
+            {savingProfile ? 'Saving…' : 'Save changes'}
+          </button>
+        </div>
+      </div>
+
+      <div class="divider"></div>
+
       <div class="info-section">
         <h2 class="section-title">Account Details</h2>
 
         <div class="info-item">
           <div class="info-label">
-            {#if browser}
-              <EnvelopeOutline class="info-icon" />
-            {/if}
+            {#if browser}<EnvelopeOutline class="info-icon" />{/if}
             <span>Email</span>
           </div>
           <div class="info-value">{user.email}</div>
@@ -58,9 +234,7 @@
 
         <div class="info-item">
           <div class="info-label">
-            {#if browser}
-              <CalendarMonthOutline class="info-icon" />
-            {/if}
+            {#if browser}<CalendarMonthOutline class="info-icon" />{/if}
             <span>Member Since</span>
           </div>
           <div class="info-value">{signupDate}</div>
@@ -68,9 +242,7 @@
 
         <button class="info-item clickable" on:click={() => goto('/favorites')}>
           <div class="info-label">
-            {#if browser}
-              <HeartSolid class="info-icon" />
-            {/if}
+            {#if browser}<HeartSolid class="info-icon" />{/if}
             <span>Favorite Locations</span>
           </div>
           <div class="info-value">{$favoritesCount}</div>
@@ -79,7 +251,6 @@
 
       <div class="divider"></div>
 
-      <!-- Taste Profile -->
       <div class="info-section">
         <h2 class="section-title">Taste Profile</h2>
         <TasteProfile />
@@ -87,12 +258,8 @@
 
       <div class="divider"></div>
 
-      <!-- Actions -->
       <div class="actions-section">
-        <button
-          class="sign-out-button"
-          on:click={handleSignOut}
-        >
+        <button class="sign-out-button" on:click={handleSignOut}>
           Sign Out
         </button>
       </div>
@@ -127,19 +294,88 @@
     margin-bottom: 2rem;
   }
 
-  .profile-icon {
-    color: #FE795D;
+  .avatar-wrapper {
+    position: relative;
     margin-bottom: 1rem;
+  }
+
+  .avatar-image {
+    width: 96px;
+    height: 96px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 3px solid #FE795D;
+    background: white;
+  }
+
+  :global(.profile-icon) {
+    color: #FE795D;
+  }
+
+  .avatar-edit-button {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: #FE795D;
+    color: white;
+    border: 2px solid white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: transform 0.15s ease, background 0.15s ease;
+  }
+
+  :global(.dark) .avatar-edit-button {
+    border-color: #1f2937;
+  }
+
+  .avatar-edit-button:hover:not(:disabled) {
+    transform: scale(1.05);
+    background: #EF562F;
+  }
+
+  .avatar-edit-button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .hidden-file-input {
+    display: none;
   }
 
   .profile-title {
     font-size: 2rem;
     font-weight: 700;
     color: #111827;
+    margin-bottom: 0.5rem;
   }
 
   :global(.dark) .profile-title {
     color: #f9fafb;
+  }
+
+  .public-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: rgba(254, 121, 93, 0.1);
+    border: 1px solid rgba(254, 121, 93, 0.3);
+    color: #FE795D;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.15s ease;
+    font-family: inherit;
+  }
+
+  .public-link:hover {
+    background: rgba(254, 121, 93, 0.18);
   }
 
   .info-card {
@@ -166,11 +402,156 @@
     font-size: 1.25rem;
     font-weight: 700;
     color: #111827;
-    margin-bottom: 1rem;
+    margin-bottom: 0.25rem;
   }
 
   :global(.dark) .section-title {
     color: #f9fafb;
+  }
+
+  .section-help {
+    font-size: 0.8125rem;
+    color: #6b7280;
+    margin-bottom: 1rem;
+  }
+
+  :global(.dark) .section-help {
+    color: #9ca3af;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+    margin-bottom: 1rem;
+  }
+
+  .field-label {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.5rem;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: #374151;
+  }
+
+  :global(.dark) .field-label {
+    color: #d1d5db;
+  }
+
+  .field-hint {
+    font-weight: 400;
+    font-size: 0.75rem;
+    color: #9ca3af;
+  }
+
+  .field-input {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.375rem;
+    background: white;
+    color: #111827;
+    font-size: 0.875rem;
+    font-family: inherit;
+    box-sizing: border-box;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  }
+
+  :global(.dark) .field-input {
+    background: #111827;
+    border-color: #374151;
+    color: #f3f4f6;
+  }
+
+  .field-input:focus {
+    outline: none;
+    border-color: #FE795D;
+    box-shadow: 0 0 0 3px rgba(254, 121, 93, 0.15);
+  }
+
+  .field-input.invalid {
+    border-color: #ef4444;
+  }
+
+  .username-input-wrapper {
+    display: flex;
+    align-items: stretch;
+    border: 1px solid #d1d5db;
+    border-radius: 0.375rem;
+    overflow: hidden;
+    background: white;
+    transition: border-color 0.15s ease;
+  }
+
+  .username-input-wrapper:focus-within {
+    border-color: #FE795D;
+    box-shadow: 0 0 0 3px rgba(254, 121, 93, 0.15);
+  }
+
+  :global(.dark) .username-input-wrapper {
+    background: #111827;
+    border-color: #374151;
+  }
+
+  .username-prefix {
+    padding: 0.5rem 0.75rem;
+    background: #f9fafb;
+    color: #6b7280;
+    font-size: 0.875rem;
+    font-family: ui-monospace, SFMono-Regular, monospace;
+    border-right: 1px solid #d1d5db;
+  }
+
+  :global(.dark) .username-prefix {
+    background: #0f172a;
+    color: #9ca3af;
+    border-right-color: #374151;
+  }
+
+  .username-input-wrapper .field-input {
+    border: none;
+    box-shadow: none;
+    border-radius: 0;
+    flex: 1;
+    font-family: ui-monospace, SFMono-Regular, monospace;
+  }
+
+  .username-input-wrapper .field-input:focus {
+    box-shadow: none;
+  }
+
+  .field-error {
+    font-size: 0.75rem;
+    color: #ef4444;
+  }
+
+  .form-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 0.5rem;
+  }
+
+  .primary-button {
+    padding: 0.5rem 1.25rem;
+    background: #FE795D;
+    color: white;
+    border: 1px solid #FE795D;
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s ease;
+  }
+
+  .primary-button:hover:not(:disabled) {
+    background: #EF562F;
+  }
+
+  .primary-button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
   }
 
   .info-item {
@@ -222,7 +603,7 @@
     color: #d1d5db;
   }
 
-  .info-icon {
+  :global(.info-icon) {
     color: #FE795D;
   }
 
@@ -241,81 +622,8 @@
     margin: 2rem 0;
   }
 
-  .coming-soon-text {
-    font-size: 0.875rem;
-    color: #6B7280;
-    margin-bottom: 1.5rem;
-  }
-
-  :global(.dark) .coming-soon-text {
-    color: #9ca3af;
-  }
-
-  .feature-grid {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-  }
-
-  .feature-item {
-    display: flex;
-    gap: 1rem;
-    padding: 1rem;
-    background: #F9FAFB;
-    border-radius: 0.5rem;
-    border: 1px solid #E5E7EB;
-    width: 100%;
-    text-align: left;
-  }
-
-  :global(.dark) .feature-item {
-    background: #111827;
-    border-color: #374151;
-  }
-
-  .feature-item.clickable {
-    cursor: pointer;
-    transition: all 0.2s;
-  }
-
-  .feature-item.clickable:hover {
-    background: white;
-    border-color: #FE795D;
-    transform: translateY(-2px);
-    box-shadow: 0 4px 6px rgba(254, 121, 93, 0.2);
-  }
-
-  :global(.dark) .feature-item.clickable:hover {
-    background: #1f2937;
-  }
-
-  .feature-icon {
-    flex-shrink: 0;
-    color: #FE795D;
-  }
-
-  .feature-content {
-    flex: 1;
-  }
-
-  .feature-title {
-    font-size: 0.875rem;
-    font-weight: 600;
-    color: #111827;
-    margin-bottom: 0.25rem;
-  }
-
-  :global(.dark) .feature-title {
-    color: #f9fafb;
-  }
-
-  .feature-description {
-    font-size: 0.75rem;
-    color: #6B7280;
-  }
-
-  :global(.dark) .feature-description {
-    color: #9ca3af;
+  :global(.dark) .divider {
+    background: #374151;
   }
 
   .actions-section {
@@ -343,12 +651,6 @@
   @media (min-width: 640px) {
     .info-item {
       padding: 1.25rem;
-    }
-
-    .feature-grid {
-      display: grid;
-      grid-template-columns: 1fr;
-      gap: 1rem;
     }
   }
 </style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
 	import { page } from '$app/stores';
 	import { initTheme } from '$lib/theme.js';
 	import { loadFavorites } from '$lib/favoritesStore.js';
+	import { loadUserVibeVotes } from '$lib/vibeVotesStore.js';
 	import { isAuthenticated } from '$lib/authStore.js';
 	import { initializeStores } from '$lib/stores.js';
 	import '../app.css';
@@ -19,9 +20,10 @@
 		// Initialize theme system (returns cleanup function)
 		const cleanupTheme = initTheme();
 
-		// Load favorites if authenticated
+		// Load user-scoped social data if authenticated
 		if ($isAuthenticated) {
 			loadFavorites();
+			loadUserVibeVotes();
 		}
 
 		// Auto-start tour for first-time visitors (delay to let map render)
@@ -39,9 +41,10 @@
 		};
 	});
 
-	// Reload favorites when authentication state changes
+	// Reload user-scoped social data when authentication state changes
 	$: if ($isAuthenticated) {
 		loadFavorites();
+		loadUserVibeVotes();
 	}
 </script>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,6 +9,7 @@
 	import '../app.css';
 	import Header from '$lib/../components/Header.svelte';
 	import TourOverlay from '$lib/../components/TourOverlay.svelte';
+	import ToastHost from '$lib/../components/ToastHost.svelte';
 	import { shouldAutoStart, startTour } from '$lib/tourStore.js';
 
 	$: isMapPage = $page.url.pathname === '/';
@@ -51,6 +52,7 @@
 <div class="app">
   <Header />
   <TourOverlay />
+  <ToastHost />
   <main class:map-page={isMapPage}>
     <slot></slot>
   </main>

--- a/src/routes/u/[username]/+page.server.js
+++ b/src/routes/u/[username]/+page.server.js
@@ -1,0 +1,30 @@
+import { error } from '@sveltejs/kit';
+
+const PUBLIC_COLUMNS = 'id, username, display_name, avatar_url, bio, created_at';
+const USERNAME_REGEX = /^[a-z0-9_]{3,20}$/;
+
+export async function load({ params, locals }) {
+	const username = (params.username || '').toLowerCase();
+	if (!USERNAME_REGEX.test(username)) {
+		throw error(404, 'Profile not found');
+	}
+
+	if (!locals.supabase) {
+		throw error(503, 'Profile lookup is unavailable right now');
+	}
+
+	const { data, error: dbError } = await locals.supabase
+		.from('profiles')
+		.select(PUBLIC_COLUMNS)
+		.eq('username', username)
+		.maybeSingle();
+
+	if (dbError) {
+		throw error(500, dbError.message);
+	}
+	if (!data) {
+		throw error(404, 'Profile not found');
+	}
+
+	return { profile: data };
+}

--- a/src/routes/u/[username]/+page.svelte
+++ b/src/routes/u/[username]/+page.svelte
@@ -1,0 +1,183 @@
+<script>
+  import { browser } from '$app/environment';
+  import { UserCircleOutline, CalendarMonthOutline } from 'flowbite-svelte-icons';
+
+  export let data;
+  $: profile = data.profile;
+
+  $: signupDate = profile?.created_at
+    ? new Date(profile.created_at).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long'
+      })
+    : '';
+</script>
+
+<svelte:head>
+  <title>{profile.display_name || profile.username} · CartoTaco</title>
+  <meta name="description" content={profile.bio || `${profile.display_name || profile.username}'s taco profile on CartoTaco`} />
+</svelte:head>
+
+<div class="profile-page">
+  <div class="profile-card">
+    <div class="profile-header">
+      <div class="avatar-wrapper">
+        {#if profile.avatar_url}
+          <img src={profile.avatar_url} alt="{profile.display_name || profile.username}'s avatar" class="avatar-image" />
+        {:else if browser}
+          <UserCircleOutline class="profile-icon" size="xl" />
+        {/if}
+      </div>
+      <h1 class="display-name">{profile.display_name || profile.username}</h1>
+      <div class="username">@{profile.username}</div>
+      {#if profile.bio}
+        <p class="bio">{profile.bio}</p>
+      {/if}
+      {#if signupDate}
+        <div class="meta">
+          {#if browser}<CalendarMonthOutline class="meta-icon" />{/if}
+          <span>Member since {signupDate}</span>
+        </div>
+      {/if}
+    </div>
+
+    <div class="placeholder-section">
+      <h2 class="section-title">Recent Check-ins</h2>
+      <p class="placeholder-text">Check-ins coming soon — when this user starts logging taco visits, they'll show up here.</p>
+    </div>
+  </div>
+</div>
+
+<style>
+  .profile-page {
+    min-height: calc(100vh - 60px);
+    padding: 2rem 1rem;
+    background: linear-gradient(135deg, #FFF5F2 0%, #FFE4DE 100%);
+  }
+
+  :global(.dark) .profile-page {
+    background: linear-gradient(135deg, #1f2937 0%, #111827 100%);
+  }
+
+  .profile-card {
+    width: 100%;
+    box-sizing: border-box;
+    max-width: 720px;
+    margin: 0 auto;
+    background: white;
+    border-radius: 0.75rem;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    padding: 2.5rem 2rem;
+  }
+
+  :global(.dark) .profile-card {
+    background: #1f2937;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+  }
+
+  .profile-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    margin-bottom: 2rem;
+  }
+
+  .avatar-wrapper {
+    margin-bottom: 1rem;
+  }
+
+  .avatar-image {
+    width: 112px;
+    height: 112px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 3px solid #FE795D;
+    background: white;
+  }
+
+  :global(.profile-icon) {
+    color: #FE795D;
+  }
+
+  .display-name {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: #111827;
+    margin: 0;
+  }
+
+  :global(.dark) .display-name {
+    color: #f9fafb;
+  }
+
+  .username {
+    color: #FE795D;
+    font-size: 0.9375rem;
+    font-weight: 500;
+    margin-top: 0.25rem;
+    font-family: ui-monospace, SFMono-Regular, monospace;
+  }
+
+  .bio {
+    color: #374151;
+    font-size: 0.9375rem;
+    line-height: 1.5;
+    max-width: 480px;
+    margin-top: 1rem;
+    margin-bottom: 0;
+  }
+
+  :global(.dark) .bio {
+    color: #d1d5db;
+  }
+
+  .meta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    color: #6b7280;
+    font-size: 0.8125rem;
+    margin-top: 1rem;
+  }
+
+  :global(.dark) .meta {
+    color: #9ca3af;
+  }
+
+  :global(.meta-icon) {
+    color: #FE795D;
+  }
+
+  .placeholder-section {
+    border-top: 1px solid #e5e7eb;
+    padding-top: 1.5rem;
+    margin-top: 1.5rem;
+  }
+
+  :global(.dark) .placeholder-section {
+    border-top-color: #374151;
+  }
+
+  .section-title {
+    font-size: 1.125rem;
+    font-weight: 700;
+    color: #111827;
+    margin-bottom: 0.5rem;
+  }
+
+  :global(.dark) .section-title {
+    color: #f9fafb;
+  }
+
+  .placeholder-text {
+    color: #6b7280;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    margin: 0;
+  }
+
+  :global(.dark) .placeholder-text {
+    color: #9ca3af;
+  }
+</style>


### PR DESCRIPTION
First two phases of the social features arc on `claude/cartotaco-social-features-4YXBO`.

## Summary

### 1. Anti-review (C6) — vibe votes
Four binary chips on every Card — 🔥 Heat Legit · ✓ Authentic · 💰 Value · ✨ Vibe — replacing the idea of star ratings or written reviews. One toggleable vote per dimension per user per spot; aggregate counts are public.

- `migrations/027_create_vibe_votes.sql` — `vibe_votes(user_id, est_id, dimension, created_at)` with `UNIQUE(user_id, est_id, dimension)`. Public `SELECT` for aggregates; `INSERT`/`DELETE` gated on `auth.uid() = user_id`.
- `src/lib/vibeVotes.js` — CRUD mirroring the favorites pattern.
- `src/lib/vibeVotesStore.js` — reactive store with optimistic toggle and a per-`est_id` aggregate cache.
- `src/components/VibeVotes.svelte` — chip row mounted on `Card.svelte` (mobile and compact desktop variants). Phosphor icons (`Flame`, `SealCheck`, `HandCoins`, `Sparkle`), `fill` weight when active. Anonymous users redirect to `/login` on click.
- New `vibe` step in the onboarding tour explains the four dimensions and the no-stars/no-essays ethos.
- `+layout.svelte` loads user vote keys on auth (and on auth state change).

### 2. iPad header layout fix
Desktop nav had 8+ items for authenticated users (theme toggle, bell, help, Summit, user email, Submit, Favorites, Profile, Sign Out) — overflowed at iPad portrait (~834 px). Bumped the breakpoint from 768 px to 1100 px so iPad portrait, split view, and similar tablet widths get the hamburger menu.

### 3. Profile foundations (Phase 2)
Public identity layer — usernames, bios, avatar uploads, and a public `/u/[username]` route — laying the groundwork for check-ins (Phase 3).

- `migrations/028_extend_profiles.sql` — adds `username` (`UNIQUE`, lowercase `[a-z0-9_]{3,20}`) and `bio` (≤280 chars). Updates the signup trigger to auto-derive a username from the email local-part with collision suffixes (`name_1`, `name_2`…). Backfills existing rows. Opens RLS `SELECT` to anon/authenticated for public profile pages — client code never selects `email` on public surfaces.
- `migrations/029_create_avatars_bucket.sql` — creates the `avatars` Storage bucket (public-read, 1 MB cap, jpeg/png/webp). RLS on `storage.objects` restricts writes to `avatars/<user_id>/…`.
- `src/lib/profiles.js` — `getOwnProfile`, `getProfileByUsername`, `updateProfile`, `uploadAvatar` (writes to `avatars/<user_id>/avatar.{ext}`, busts browser cache via `?t=` query param).
- `src/lib/toastStore.js` + `src/components/ToastHost.svelte` — small non-blocking notification system, mounted once in `+layout`. Used by the profile editor to confirm saves and surface errors.
- `/profile` editor — display name, username with `/u/` prefix and live validation, 280-char bio with remaining-character counter, avatar uploader with preview, "Copy public profile link" button.
- `/u/[username]` public route — server-side load with `maybeSingle()` and `error(404)` on miss. Renders avatar, display name, `@username`, bio, member-since. Recent check-ins block is a labeled placeholder for Phase 3.

## Migrations to run (in order)

1. `027_create_vibe_votes.sql`
2. `028_extend_profiles.sql`
3. `029_create_avatars_bucket.sql` — if the `INSERT INTO storage.buckets` row errors due to permissions, create the `avatars` bucket via the Supabase dashboard (Storage → New bucket → name `avatars`, public, 1 MB, mime types `image/jpeg, image/png, image/webp`) and run only the `CREATE POLICY` block.

## Test plan

- [x] Run migrations 027 → 028 → 029 against Supabase
- [x] Anti-review: tap each chip on 2–3 spots, confirm aggregate updates and persists across reload; signed-out click redirects to `/login`
- [x] Tour: trigger `?tour=1` (or via help button) and confirm new "Vibe Check" step appears between map and theme
- [x] iPad portrait: verify hamburger menu is shown (not overflowing desktop nav)
- [x] Profile editor: change display name, username, bio, upload an avatar; confirm toasts fire on save/error; confirm `/u/<your-username>` renders the new values
- [x] Username collision: try claiming a taken username, confirm validation error
- [x] Public profile: visit `/u/<other-user>` while signed-out — should render without redirect; visit `/u/no-such-user` → 404

https://claude.ai/code/session_015m1dHdgw3Mjm76wVaShH3Q