### PR TITLE
chore: maintenance pass — docs, migration table, and warning cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ VITE_MAPBOX_KEY=your_mapbox_api_key
 Detailed documentation for all features:
 
 - **[Improvements Roadmap](docs/IMPROVEMENTS.md)** - Planned features and enhancements
+- **[Deployment & CI/CD](docs/DEPLOYMENT.md)** - Staging/production workflow and GitHub Actions
 - **[Query Optimization](docs/QUERY_OPTIMIZATION.md)** - Database view implementation
 - **[Search & Filter](docs/SEARCH_FILTER.md)** - Filter system documentation
 - **[Marker Clustering](docs/MARKER_CLUSTERING.md)** - Clustering implementation
@@ -126,21 +127,25 @@ src/
 │   ├── tourStore.js         # Onboarding tour state
 │   ├── uiStore.js           # UI state (filter panel, mobile nav)
 │   ├── newSpotsStore.js     # New spots notification state
+│   ├── vibeVotesStore.js    # Anti-review vibe vote state
+│   ├── toastStore.js        # Non-blocking toast notifications
 │   ├── mapping.js           # Mapbox GL rendering with clustering
 │   ├── mapStore.js          # Mapbox map instance holder
 │   ├── dataWrangling.js     # Data transformation utilities
 │   ├── supabase.js          # Supabase server client
 │   ├── supabaseBrowser.js   # Supabase browser client (SSR cookie support)
-│   └── ...                  # geocoding, validation, theme, deviceDetection
+│   └── ...                  # geocoding, validation, theme, deviceDetection, profiles
 ├── routes/                  # SvelteKit routes
 │   ├── +page.svelte         # Main map page
 │   ├── Map.svelte           # Map component
 │   ├── compare/             # Spot comparison page (shareable via ?ids=)
+│   ├── vote/                # Taco Summit creation (/vote/new) and voting (/vote/[id])
+│   ├── u/[username]/        # Public user profile page
 │   ├── (auth)/              # Login, signup, email confirmation
 │   └── (protected)/         # Favorites, profile, submit (requires auth)
 ├── app.css                  # Global styles
 docs/                        # Feature documentation
-migrations/                  # Database migrations (001-020)
+migrations/                  # Database migrations (001-029)
 schema/                      # Canonical view definitions
 ```
 
@@ -159,7 +164,7 @@ The application uses Supabase with the following main tables:
 
 ### Running Migrations
 
-After setting up your Supabase project, run the 20 migrations in order. See [CLAUDE.md](CLAUDE.md) for the full migration list and [migrations/README.md](migrations/README.md) for detailed instructions.
+After setting up your Supabase project, run the 29 migrations in order. See [CLAUDE.md](CLAUDE.md) for the full migration list and [migrations/README.md](migrations/README.md) for detailed instructions.
 
 ## 🌟 Roadmap
 
@@ -180,14 +185,20 @@ See [docs/IMPROVEMENTS.md](docs/IMPROVEMENTS.md) for the complete feature roadma
 - ✅ Directions deep-link
 - ✅ New spots badge
 - ✅ Vercel deployment
+- ✅ "Surprise Me" random spot picker
+- ✅ Taco Summit group ranked-choice voting
+- ✅ Anti-review Vibe Votes (Heat Legit / Authentic / Value / Vibe)
+- ✅ User profiles (username, bio, avatar, public `/u/[username]`)
+- ✅ Toast notification system
+- ✅ Staging/production CI pipeline with automated migrations
 
 **Next Up:**
-- "Surprise Me" random spot picker
+- Check-ins + Aficionado Tiers (geo-fenced check-ins, tier badges)
+- Meetups (in-person events as a map layer with RSVPs)
 - Taco Tuesday Tracker
 - Tucson Taco Census stats page
-- Community ratings & reviews
+- Accessibility audit (WCAG 2.1)
 - PWA support
-- Accessibility audit
 
 ## 🤝 Contributing
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,124 @@
+# Deployment & CI/CD Workflow
+
+CartoTaco uses a **staging → production** Git flow backed by Vercel (frontend) and Supabase (database), with GitHub Actions handling automated migrations on push.
+
+---
+
+## Environments
+
+| Environment | Git Branch | Vercel URL | Supabase Project |
+|---|---|---|---|
+| Staging | `staging` | auto-deployed by Vercel | `SUPABASE_DB_URL_STAGING` secret |
+| Production | `main` | auto-deployed by Vercel | `SUPABASE_DB_URL_PROD` secret |
+
+Both environments use the same codebase; environment-specific config is supplied via Vercel's environment variable settings per deployment target.
+
+---
+
+## Standard Release Flow
+
+1. **Develop on a feature branch** (`feature/my-feature` or a Claude-generated branch).
+2. **Open a PR → `staging`**. Vercel builds a preview URL for the branch automatically.
+3. **Merge to `staging`**. This triggers:
+   - Vercel deploys the new code to the staging environment.
+   - GitHub Actions runs `.github/workflows/migrate.yml`, which applies any new migrations to the staging Supabase project via `supabase db push`.
+4. **Test on staging** using the staging Vercel URL and the staging Supabase project.
+5. **Open a PR from `staging` → `main`** when ready to ship.
+6. **Merge to `main`**. This triggers:
+   - Vercel deploys to production.
+   - GitHub Actions runs `.github/workflows/migrate.yml` again, applying migrations to the production Supabase project.
+
+---
+
+## GitHub Actions Workflows
+
+### `migrate.yml` — Automated Database Migrations
+
+**Trigger**: push to `staging` or `main`
+
+**What it does**: Runs `supabase db push` against the correct Supabase project based on the branch.
+
+**Required repository secrets**:
+| Secret | Description |
+|---|---|
+| `SUPABASE_ACCESS_TOKEN` | Supabase CLI personal access token |
+| `SUPABASE_DB_URL_STAGING` | Full Postgres connection string for staging DB |
+| `SUPABASE_DB_URL_PROD` | Full Postgres connection string for production DB |
+
+The connection strings follow the format:
+```
+postgresql://postgres.[project-ref]:[password]@aws-0-[region].pooler.supabase.com:5432/postgres
+```
+
+### `seed-staging.yml` — Seed Staging from Production
+
+**Trigger**: Manual only (`workflow_dispatch`)
+
+**What it does**: Dumps the production database with `pg_dump` and restores it into staging with `psql`. Useful after a major data entry session in production, or when setting up a fresh staging environment.
+
+**Required secrets**: same as above (`SUPABASE_DB_URL_PROD`, `SUPABASE_DB_URL_STAGING`)
+
+**When to run**:
+- After adding significant data in production that staging needs (e.g., a batch of new taco spots).
+- When resetting staging to match production for a clean test baseline.
+
+> **Warning**: This overwrites all staging data. Run it deliberately, not routinely.
+
+---
+
+## Writing Migrations
+
+1. Create a new file in `migrations/` following the naming convention: `NNN_description.sql` where `NNN` is the next sequential number (zero-padded to 3 digits).
+2. Update `schema/sites_complete_view.sql` if the migration changes the `sites_complete` view (this is the canonical source of truth — copy from it into the migration, not the other way around).
+3. Update `migrations/README.md` to document the new migration in the table.
+4. Update `CLAUDE.md` to add the migration to the ordered list.
+
+Migrations are applied in filename order by `supabase db push`. They are **not idempotent by default** — wrap destructive operations in `IF EXISTS` guards where appropriate.
+
+---
+
+## Environment Variables
+
+### Frontend (Vercel)
+
+Set these in the Vercel dashboard under **Settings → Environment Variables**, scoped per environment:
+
+| Variable | Description |
+|---|---|
+| `VITE_SUPABASE_URL` | Supabase project URL |
+| `VITE_SUPABASE_ANON_KEY` | Supabase anonymous key (public) |
+| `VITE_MAPBOX_KEY` | Mapbox public token |
+
+### Local Development
+
+Copy `.env.example` (if present) or create `.env` manually:
+
+```
+VITE_SUPABASE_URL=your_supabase_url
+VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
+VITE_MAPBOX_KEY=your_mapbox_api_key
+```
+
+---
+
+## Vercel Configuration
+
+`vercel.json` at the repo root configures the Vercel deployment. The SvelteKit adapter is `@sveltejs/adapter-vercel` with `runtime: 'nodejs20.x'` set in `svelte.config.js`.
+
+> **Note**: `runtime: 'nodejs20.x'` in the adapter config is deprecated in newer adapter versions; Node version should eventually be configured at the Vercel project level instead. No immediate action needed.
+
+---
+
+## Rollback Procedures
+
+### Frontend
+
+Revert via Vercel's **Deployments** tab — every deployment is retained and can be re-promoted to production instantly.
+
+### Database
+
+Migrations are not auto-rolled back. To undo a migration:
+1. Write a new migration that reverses the change (e.g., `DROP TABLE`, `ALTER TABLE ... DROP COLUMN`).
+2. Merge it through the normal staging → production flow.
+
+The `migrations/README.md` documents rollback SQL for critical migrations (view, Taco Summit tables).

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -663,4 +663,4 @@ Sample challenges:
 
 ---
 
-**Last Updated**: 2026-05-04 — Added Social Features Arc section (Phases 1–6); marked C6, Profile Foundations, Toast system, iPad header fix as shipped; superseded ratings/reviews item in favor of the arc.
+**Last Updated**: 2026-05-18 — Updated migrations table to 029; added staging/prod deployment workflow to docs. No shipped features since 2026-05-04.

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -41,6 +41,12 @@ Run in order. Each migration depends on the previous ones.
 | 021 | `021_create_group_sessions.sql` | Creates `group_sessions` table for Taco Summit (`id`, `creator_token`, `site_ids`, `title`, `closed_at`) with open RLS |
 | 022 | `022_create_group_votes.sql` | Creates `group_votes` table for ranked-choice ballots (`session_id`, `voter_token`, `est_id`, `rank`) with unique constraint, index, and open RLS |
 | 023 | `023_add_snacks_menu_type.sql` | Adds snacks as a menu type |
+| 024 | `024_enable_rls_staging_extractions.sql` | Enables RLS on `staging_extractions` table; authenticated users get SELECT/INSERT/UPDATE, anonymous blocked |
+| 025 | `025_fix_sites_complete_security_invoker.sql` | Fixes SECURITY DEFINER warning on `sites_complete` view by setting `security_invoker = true` (PostgreSQL 15+) |
+| 026 | `026_add_quesadilla_to_view.sql` | Adds `quesadilla_yes` / `quesadilla_perc` to `sites_complete` view |
+| 027 | `027_create_vibe_votes.sql` | Creates `vibe_votes` table for Anti-Review feature (binary emoji votes: heat_legit, authentic, value, vibe) with public SELECT and auth-gated INSERT/DELETE |
+| 028 | `028_extend_profiles.sql` | Adds `username` (UNIQUE slug) and `bio` (≤280 chars) to `profiles`; auto-generates username on signup; opens SELECT to anon for `/u/[username]` browsing |
+| 029 | `029_create_avatars_bucket.sql` | Creates the `avatars` Storage bucket (public-read, 1 MB cap, image/* mime types) with user-scoped RLS on `storage.objects` |
 
 ## Rollback
 

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -282,10 +282,6 @@
     color: #d1d5db;
   }
 
-  .user-icon {
-    color: #FE795D;
-  }
-
   .user-email {
     max-width: 200px;
     overflow: hidden;

--- a/src/components/NewSpotsBadge.svelte
+++ b/src/components/NewSpotsBadge.svelte
@@ -140,11 +140,13 @@
         class="mobile-panel-overlay"
         use:portal
         on:click={closeDropdown}
+        on:keydown={(e) => e.key === 'Escape' && closeDropdown()}
         role="button"
         tabindex="-1"
         aria-label="Close panel"
       >
-        <div class="mobile-panel" on:click|stopPropagation>
+        <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+        <div class="mobile-panel" role="dialog" aria-modal="true" on:click|stopPropagation on:keydown|stopPropagation>
           <div class="panel-header">
             <h3 class="panel-title">New Spots</h3>
             <button class="close-button" on:click={closeDropdown} aria-label="Close">×</button>

--- a/src/routes/(auth)/auth/confirm/+page.svelte
+++ b/src/routes/(auth)/auth/confirm/+page.svelte
@@ -124,14 +124,6 @@
     }
   }
 
-  .success-icon {
-    color: #059669;
-  }
-
-  .error-icon {
-    color: #DC2626;
-  }
-
   .title {
     font-size: 1.5rem;
     font-weight: 700;

--- a/src/routes/(auth)/signup/+page.svelte
+++ b/src/routes/(auth)/signup/+page.svelte
@@ -303,11 +303,6 @@
     align-items: start;
   }
 
-  .success-icon {
-    flex-shrink: 0;
-    color: #059669;
-  }
-
   .success-title {
     font-weight: 600;
     margin-bottom: 0.25rem;

--- a/src/routes/(protected)/favorites/+page.svelte
+++ b/src/routes/(protected)/favorites/+page.svelte
@@ -8,8 +8,6 @@
 	import { processedTacoData } from '$lib/stores';
 	import FavoriteButton from '../../../components/FavoriteButton.svelte';
 
-	export let data;
-
 	let favoriteLocations = [];
 	let loading = true;
 
@@ -159,11 +157,6 @@
 		align-items: center;
 		text-align: center;
 		margin-bottom: 2rem;
-	}
-
-	.header-icon {
-		color: #FE795D;
-		margin-bottom: 1rem;
 	}
 
 	.favorites-title {
@@ -361,11 +354,6 @@
 
 	.detail-value.address {
 		line-height: 1.4;
-	}
-
-	.detail-icon {
-		color: #FE795D;
-		flex-shrink: 0;
 	}
 
 	.card-description {

--- a/src/routes/(protected)/submit/+page.svelte
+++ b/src/routes/(protected)/submit/+page.svelte
@@ -6,8 +6,6 @@
 	import { validateSubmissionForm } from '$lib/validation.js';
 	import { submitLocation } from '$lib/submissions.js';
 
-	export let data;
-
 	// Form state
 	let formData = {
 		name: '',


### PR DESCRIPTION
- README: mark all shipped features complete (Surprise Me, Taco Summit,
  Vibe Votes, Profiles, Toast, CI pipeline); update migration count to
  29; add vote/ and u/[username] routes to project structure; add newer
  stores (vibeVotesStore, toastStore); link new DEPLOYMENT.md
- docs/DEPLOYMENT.md: new file documenting staging → production Git
  flow, GitHub Actions workflows (migrate.yml + seed-staging.yml),
  required secrets, migration authoring workflow, and rollback procedures
- migrations/README.md: document migrations 024–029
- docs/IMPROVEMENTS.md: bump Last Updated date
- Fix 11 svelte-check warnings (0 errors, 0 warnings now):
  - Remove unused CSS selectors in Header, auth/confirm, signup,
    favorites pages
  - Remove unused `export let data` props in favorites and submit pages
  - Fix A11y warnings in NewSpotsBadge mobile panel (keyboard handler on
    overlay, dialog role + aria-modal on panel, svelte-ignore for
    legitimate stopPropagation on dialog)
- All 78 unit tests still passing

https://claude.ai/code/session_01N5WDJHfWzjdo17PYr1Q7PN